### PR TITLE
[#154] Implement WebSocket support.

### DIFF
--- a/examples/websockets/client.ts
+++ b/examples/websockets/client.ts
@@ -3,6 +3,7 @@ const socket = new WebSocket("ws://localhost:3000/ws");
 
 socket.addEventListener("open", (e) => {
   socket.send("ping");
+  console.log("sent ping to server");
 });
 
 socket.addEventListener("close", (_) => {
@@ -10,9 +11,11 @@ socket.addEventListener("close", (_) => {
 });
 
 socket.addEventListener("message", (e) => {
-  console.log(`Received msg "${e.data}" from server.`);
   if (e.data === "ping") {
+    console.log("Received ping from server. Responding...");
     socket.send("pong");
+  } else if (e.data === "pong") {
+    console.log("Received ping response from server.");
   }
 });
 

--- a/examples/websockets/client.ts
+++ b/examples/websockets/client.ts
@@ -1,0 +1,21 @@
+console.log("Client started");
+const socket = new WebSocket("ws://localhost:3000/ws");
+
+socket.addEventListener("open", (e) => {
+  socket.send("ping");
+});
+
+socket.addEventListener("close", (_) => {
+  console.log("socket closed :(");
+});
+
+socket.addEventListener("message", (e) => {
+  console.log(`Received msg "${e.data}" from server.`);
+  if (e.data === "ping") {
+    socket.send("pong");
+  }
+});
+
+socket.addEventListener("error", (e) => {
+  console.error(`Had error`, e);
+});

--- a/examples/websockets/server.ts
+++ b/examples/websockets/server.ts
@@ -1,0 +1,66 @@
+/**
+ * Run this example using:
+ *
+ *    deno run --allow-read --allow-net ./examples/websockets/server.ts
+ *
+ *    if have the repo cloned locally OR
+ *
+ *    deno run --allow-read --allow-net https://raw.githubusercontent.com/cmorten/opine/main/examples/websockets/server.ts
+ *
+ *    if you don't!
+ *
+ * After running the example, run the client with:
+ *
+ *    deno run --allow-net ./examples/websockets/client.ts
+ *
+ *    (OR)
+ *
+ *    deno run --allow-net https://raw.githubusercontent.com/cmorten/opine/main/examples/websockets/server.ts
+ */
+
+import { opine } from "../../mod.ts";
+
+const app = opine();
+const sockets = new Map<string, WebSocket>();
+
+const handleWs = async (socket: WebSocket) => {
+  sockets.set(crypto.randomUUID(), socket);
+  socket.addEventListener("open", (e) => {
+    socket.send("ping");
+  });
+  socket.addEventListener("close", (_) => {
+    console.log("socket closed :(");
+  });
+
+  socket.addEventListener("message", (e) => {
+    console.log(`Received msg "${e.data}" from client.`);
+    if (e.data === "ping") {
+      socket.send("pong");
+    }
+  });
+};
+
+app.get("/ws", async (req, res, next) => {
+  if (req.headers.get("upgrade") === "websocket") {
+    const sock = req.upgrade(res);
+    await handleWs(sock);
+  } else {
+    res.send("You've gotta set the magic header...");
+  }
+
+  next();
+});
+
+app.use((_, res, __) => {
+  res.setHeader("access-control-allow-origin", "*");
+  res.setHeader(
+    "access-control-expose-headers",
+    "Upgrade,sec-websocket-accept,connection",
+  );
+
+  res.send();
+});
+
+app.listen(3000, () => {
+  console.log("Opine listening on port 3000.");
+});

--- a/examples/websockets/server.ts
+++ b/examples/websockets/server.ts
@@ -27,15 +27,18 @@ const handleWs = async (socket: WebSocket) => {
   sockets.set(crypto.randomUUID(), socket);
   socket.addEventListener("open", (e) => {
     socket.send("ping");
+    console.log("sent ping to client");
   });
   socket.addEventListener("close", (_) => {
     console.log("socket closed :(");
   });
 
   socket.addEventListener("message", (e) => {
-    console.log(`Received msg "${e.data}" from client.`);
     if (e.data === "ping") {
+      console.log("Received ping from client. Responding...");
       socket.send("pong");
+    } else if (e.data === "pong") {
+      console.log("Received ping response from client.");
     }
   });
 };

--- a/src/request.ts
+++ b/src/request.ts
@@ -85,7 +85,9 @@ export class WrappedRequest implements OpineRequest {
       ? readableStreamFromReader(response.body)
       : response.body;
 
-    this.#responsePromiseResolver(new Response(bodyInit, response));
+    this.#responsePromiseResolver(
+      response.wsUpgrade || new Response(bodyInit, response),
+    );
   }
 
   /**
@@ -298,6 +300,12 @@ export class WrappedRequest implements OpineRequest {
     }
 
     return typeofrequest(this.headers, arr as string[]);
+  }
+
+  upgrade(res: OpineResponse): WebSocket {
+    const { socket, response } = Deno.upgradeWebSocket(this.#request);
+    res.wsUpgrade = response;
+    return socket;
   }
 
   get #body() {

--- a/src/request.ts
+++ b/src/request.ts
@@ -85,9 +85,7 @@ export class WrappedRequest implements OpineRequest {
       ? readableStreamFromReader(response.body)
       : response.body;
 
-    this.#responsePromiseResolver(
-      response.wsUpgrade || new Response(bodyInit, response),
-    );
+    this.#responsePromiseResolver(new Response(bodyInit, response));
   }
 
   /**
@@ -304,7 +302,7 @@ export class WrappedRequest implements OpineRequest {
 
   upgrade(res: OpineResponse): WebSocket {
     const { socket, response } = Deno.upgradeWebSocket(this.#request);
-    res.wsUpgrade = response;
+    this.#responsePromiseResolver(response);
     return socket;
   }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -45,7 +45,6 @@ export class Response implements OpineResponse {
   app!: Application;
   req!: OpineRequest;
   locals!: any;
-  wsUpgrade: globalThis.Response | null = null;
 
   #resources: number[] = [];
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -45,6 +45,7 @@ export class Response implements OpineResponse {
   app!: Application;
   req!: OpineRequest;
   locals!: any;
+  wsUpgrade: globalThis.Response | null = null;
 
   #resources: number[] = [];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -646,14 +646,6 @@ export interface OpineResponse<ResBody = any> extends Opine.Response {
   statusMessage?: any;
 
   /**
-   * # DON'T TOUCH THIS!
-   * Internal member holding the WebSocket upgrade response if OpineRequest.upgrade is called.
-   * Cannot be marked as readonly since it needs to be set at runtime.
-   * @internal
-   */
-  wsUpgrade: globalThis.Response | null;
-
-  /**
    * Boolean signifying whether the request has already been responded to.
    */
   written: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -441,6 +441,25 @@ export interface OpineRequest<
   is(type: string | string[]): string | boolean | null;
 
   /**
+   * Upgrade an HTTP connection to a WebSocket connection by calling Deno.upgradeWebSocket.
+   *
+   * Example:
+   *
+   *     app.get("/ws", async (req, res, next) => {
+   *       if (req.headers.get("upgrade") === "websocket") {
+   *         const sock = req.upgrade(res);
+   *         await handleWs(sock);
+   *       } else {
+   *         res.send("You've gotta set the magic header...");
+   *       }
+   *       next();
+   *     });
+   * @param res The response object that will contain the WebSocket response we need to send.
+   * @returns A socket object.
+   */
+  upgrade(res: OpineResponse): WebSocket;
+
+  /**
    * Return the protocol string "http" or "https"
    * when requested with TLS. When the "trust proxy"
    * setting is enabled the "X-Forwarded-Proto" header
@@ -625,6 +644,14 @@ export interface OpineResponse<ResBody = any> extends Opine.Response {
   locals: any;
 
   statusMessage?: any;
+
+  /**
+   * # DON'T TOUCH THIS!
+   * Internal member holding the WebSocket upgrade response if OpineRequest.upgrade is called.
+   * Cannot be marked as readonly since it needs to be set at runtime.
+   * @internal
+   */
+  wsUpgrade: globalThis.Response | null;
 
   /**
    * Boolean signifying whether the request has already been responded to.


### PR DESCRIPTION
# Issue

Fixes #154.

## Details

This PR implements the ability to upgrade an HTTP connection into a WebSocket one by implementing an `upgrade()` method on the `OpineRequest` object. (See discussion in linked issue.)

## Checklist

- [x] PR starts with #154.
- [x] Has been tested (where required). (Haven't tested this extensively, but the basic example I wrote works.)
