### PR TITLE
[#156] Replace deprecated `Deno.readAll`

### DIFF
--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -120,10 +120,12 @@ middleware to transform `req.body` into a raw string:
 ```ts
 import opine from "https://deno.land/x/opine@2.1.1/mod.ts";
 
+import { readAll } from "https://deno.land/std@0.120.0/streams/conversion.ts";
+
 const app = opine();
 
 const bodyParser = async function (req, res, next) {
-  const rawBody = await Deno.readAll(req.raw);
+  const rawBody = await readAll(req.raw);
   const decodedBody = decoder.decode(rawBody);
 
   req.body = decodedBody;

--- a/deps.ts
+++ b/deps.ts
@@ -26,8 +26,8 @@ export { default as EventEmitter } from "https://deno.land/std@0.120.0/node/even
 export { Sha1 } from "https://deno.land/std@0.120.0/hash/sha1.ts";
 export {
   readableStreamFromReader,
+  readAll,
   readerFromStreamReader,
-  readAll
 } from "https://deno.land/std@0.120.0/streams/conversion.ts";
 
 export {

--- a/deps.ts
+++ b/deps.ts
@@ -27,6 +27,7 @@ export { Sha1 } from "https://deno.land/std@0.120.0/hash/sha1.ts";
 export {
   readableStreamFromReader,
   readerFromStreamReader,
+  readAll
 } from "https://deno.land/std@0.120.0/streams/conversion.ts";
 
 export {

--- a/src/middleware/bodyParser/read.ts
+++ b/src/middleware/bodyParser/read.ts
@@ -33,7 +33,7 @@ import type { NextFunction, OpineRequest, OpineResponse } from "../../types.ts";
 import {
   gunzip as createGunzip,
   inflate as createInflate,
-  readAll
+  readAll,
 } from "../../../deps.ts";
 import { createError } from "../../utils/createError.ts";
 

--- a/src/middleware/bodyParser/read.ts
+++ b/src/middleware/bodyParser/read.ts
@@ -33,6 +33,7 @@ import type { NextFunction, OpineRequest, OpineResponse } from "../../types.ts";
 import {
   gunzip as createGunzip,
   inflate as createInflate,
+  readAll
 } from "../../../deps.ts";
 import { createError } from "../../utils/createError.ts";
 
@@ -123,7 +124,7 @@ async function decodeContent(
 
   let raw;
   try {
-    raw = await Deno.readAll(req.body);
+    raw = await readAll(req.body);
   } catch (err) {
     throw createError(400, err);
   }

--- a/test/units/middleware.basic.test.ts
+++ b/test/units/middleware.basic.test.ts
@@ -1,5 +1,5 @@
 import { opine } from "../../mod.ts";
-import { expect, superdeno } from "../deps.ts";
+import { expect, superdeno, readAll } from "../deps.ts";
 import { describe, it } from "../utils.ts";
 
 describe("middleware", function () {
@@ -20,7 +20,7 @@ describe("middleware", function () {
 
       app.use(async function (req, res) {
         res.set("Content-Type", "application/json; charset=utf-8");
-        const raw = await Deno.readAll(req.body);
+        const raw = await readAll(req.body);
         const data = (new TextDecoder()).decode(raw);
         res.end(data);
       });

--- a/test/units/middleware.basic.test.ts
+++ b/test/units/middleware.basic.test.ts
@@ -1,5 +1,5 @@
 import { opine } from "../../mod.ts";
-import { expect, superdeno, readAll } from "../deps.ts";
+import { expect, readAll, superdeno } from "../deps.ts";
 import { describe, it } from "../utils.ts";
 
 describe("middleware", function () {

--- a/test/units/middleware.basic.test.ts
+++ b/test/units/middleware.basic.test.ts
@@ -1,5 +1,6 @@
 import { opine } from "../../mod.ts";
-import { expect, readAll, superdeno } from "../deps.ts";
+import { expect, superdeno } from "../deps.ts";
+import { readAll } from "../../deps.ts";
 import { describe, it } from "../utils.ts";
 
 describe("middleware", function () {


### PR DESCRIPTION
# Issue

Fixes #156

## Details

Remove deprecated API `Deno.readAll` with appropriate replacement

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
