### PR TITLE
[#158] [#159] Add `formData()` API to Opine `Request` class

### DIFF
--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -466,6 +466,18 @@ Returns the first accepted language of the specified languages, based on the
 request's `Accept-Language` HTTP header field. If none of the specified
 languages is accepted, returns empty.
 
+#### async req.formData()
+
+Takes the request stream and reads it to completion, returning a promise that resolves with a `FormData` object.
+
+```ts
+const formData = await req.formData();
+
+for (const entry of formData) {
+  console.log(entry);
+}
+```
+
 #### req.get(field)
 
 Returns the specified HTTP request header field (case-insensitive match). The

--- a/src/request.ts
+++ b/src/request.ts
@@ -309,17 +309,22 @@ export class WrappedRequest implements OpineRequest {
 
   /**
    * Takes the `Request` stream and reads it to completion.
-   * 
+   *
    * Returns a promise that resolves with a `FormData` object.
    */
   async formData(): Promise<FormData> {
-    if (this.body instanceof FormData) {
-      return this.body;
-    } else if (this._parsedBody) {
-      throw new TypeError();
+    if (this.parsedBody instanceof FormData) {
+      return this.parsedBody;
     }
 
-    const formData = await this.#request.formData();
+    let formData: FormData;
+
+    try {
+      formData = await this.#request.formData();
+    } catch {
+      throw new TypeError("Body can not be decoded as form data");
+    }
+
     this.body = formData;
 
     return formData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,12 +461,12 @@ export interface OpineRequest<
 
   /**
    * Takes the `Request` stream and reads it to completion.
-   * 
+   *
    * Returns a promise that resolves with a `FormData` object.
-   * 
+   *
    * @returns A `FormData` object.
    */
-   formData(): Promise<FormData>;
+  formData(): Promise<FormData>;
 
   /**
    * Return the protocol string "http" or "https"

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,6 +460,15 @@ export interface OpineRequest<
   upgrade(): WebSocket;
 
   /**
+   * Takes the `Request` stream and reads it to completion.
+   * 
+   * Returns a promise that resolves with a `FormData` object.
+   * 
+   * @returns A `FormData` object.
+   */
+   formData(): Promise<FormData>;
+
+  /**
    * Return the protocol string "http" or "https"
    * when requested with TLS. When the "trust proxy"
    * setting is enabled the "X-Forwarded-Proto" header

--- a/test/units/req.formData.test.ts
+++ b/test/units/req.formData.test.ts
@@ -1,0 +1,119 @@
+import { opine } from "../../mod.ts";
+import { expect, superdeno } from "../deps.ts";
+import { describe, it } from "../utils.ts";
+
+describe("req", function () {
+  describe(".formData", function () {
+    it(
+      "should resolve to FormData when the request is a valid `multipart/form-data` request",
+      function (done) {
+        const app = opine();
+
+        app.use(async function (req, res) {
+          const formData = await req.formData();
+
+          res.send(new URLSearchParams(formData as any).toString());
+        });
+
+        superdeno(app)
+          .post("/")
+          .field("type", "text")
+          .attach("file", "test/fixtures/name.txt")
+          .expect(200, "type=text&file=test%2Ffixtures%2Fname.txt", done);
+      },
+    );
+
+    it(
+      "should resolve the form data if already been parsed",
+      function (done) {
+        const app = opine();
+
+        app.use(async function (req, res) {
+          await req.formData();
+          const formData = await req.formData();
+
+          res.send(new URLSearchParams(formData as any).toString());
+        });
+
+        superdeno(app)
+          .post("/")
+          .field("type", "text")
+          .attach("file", "test/fixtures/name.txt")
+          .expect(200, "type=text&file=test%2Ffixtures%2Fname.txt", done);
+      },
+    );
+
+    it(
+      "should reject when the request is not `multipart/form-data` - GET request",
+      function (done) {
+        const app = opine();
+
+        app.use(async function (req, res) {
+          try {
+            await req.formData();
+
+            res.setStatus(500).end();
+          } catch (e) {
+            expect(e).toEqual(
+              new TypeError("Body can not be decoded as form data"),
+            );
+            res.end();
+          }
+        });
+
+        superdeno(app)
+          .get("/")
+          .expect(200, done);
+      },
+    );
+
+    it(
+      "should reject when the request is not `multipart/form-data` - POST `application/json` request",
+      function (done) {
+        const app = opine();
+
+        app.use(async function (req, res) {
+          try {
+            await req.formData();
+
+            res.setStatus(500).end();
+          } catch (e) {
+            expect(e).toEqual(
+              new TypeError("Body can not be decoded as form data"),
+            );
+            res.end();
+          }
+        });
+
+        superdeno(app)
+          .post("/")
+          .send({ name: "deno" })
+          .expect(200, done);
+      },
+    );
+
+    it(
+      "should reject if the request body has already been consumed and it isn't form data",
+      function (done) {
+        const app = opine();
+
+        app.use(async function (req, res) {
+          try {
+            req.body;
+
+            await req.formData();
+
+            res.setStatus(500).end();
+          } catch {
+            res.end();
+          }
+        });
+
+        superdeno(app)
+          .post("/")
+          .send({ name: "deno" })
+          .expect(200, done);
+      },
+    );
+  });
+});


### PR DESCRIPTION
# Issue

Fixes #158
Fixes #159

## Details

Adds a `Request.formData()` API to Opine for dealing with `multipart/form-data`.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [ ] Has been tested (where required).
