### PR TITLE
[#158] [#159] implement formData parser

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -29,7 +29,7 @@ export {
   readAll,
   readerFromStreamReader,
 } from "https://deno.land/std@0.126.0/streams/conversion.ts";
-
+export { MultipartReader } from "https://deno.land/std@0.126.0/mime/mod.ts";
 export {
   charset,
   contentType,

--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,7 @@ export * from "./src/types.ts";
 export { query } from "./src/middleware/query.ts";
 export { json } from "./src/middleware/bodyParser/json.ts";
 export { raw } from "./src/middleware/bodyParser/raw.ts";
+export { formData } from "./src/middleware/bodyParser/formData.ts";
 export { text } from "./src/middleware/bodyParser/text.ts";
 export { urlencoded } from "./src/middleware/bodyParser/urlencoded.ts";
 export { serveStatic } from "./src/middleware/serveStatic.ts";

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -60,7 +60,7 @@ export function formData(options: any = {}) {
     const multipartReader = new MultipartReader(req.raw, boundary.at(-1) || "");
     const customFormData = new FormData();
 
-    const body = await multipartReader.readForm();
+    const body = await multipartReader.readForm(options.maxMemory || 15728640);
 
     for (const [key, value] of body) {
       value?.forEach(async (formValue) => {

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -66,22 +66,23 @@ export function formData(options: any = {}) {
       return;
     }
 
-    const mr = new MultipartReader(req.raw, boundary[boundary.length - 1]);
-    const body = await mr.readForm();
+    const multipartReader = new MultipartReader(req.raw, boundary[boundary.length - 1]);
     const customFormData = new FormData();
 
+    const body = await multipartReader.readForm();
+
     for (const [key, value] of body) {
-      value?.forEach(async (v) => {
-        if (typeof v === "string") {
-          customFormData.append(key, v);
+      value?.forEach(async (formValue) => {
+        if (typeof formValue === "string") {
+          customFormData.append(key, formValue);
         } else {
-          let buffer = v.content;
+          let buffer = formValue.content;
 
           if (!buffer) {
-            buffer = await Deno.readFile(v.filename);
+            buffer = await Deno.readFile(formValue.filename);
           }
 
-          const file = new File([buffer], v.filename);
+          const file = new File([buffer], formValue.filename);
 
           customFormData.append(key, file);
         }

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -11,11 +11,6 @@ import { typeChecker } from "./typeChecker.ts";
  */
 export function formData(options: any = {}) {
   const type = options.type || "multipart/form-data";
-  const verify = options.verify || false;
-
-  if (verify !== false && typeof verify !== "function") {
-    throw new TypeError("option verify must be function");
-  }
 
   // create the appropriate type checking function
   const shouldParse = typeof type !== "function" ? typeChecker(type) : type;

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -1,0 +1,113 @@
+/*!
+ * Port of body-parser (https://github.com/expressjs/body-parser) for Deno.
+ *
+ * Licensed as follows:
+ *
+ * (The MIT License)
+ *
+ * Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+ * Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+import { getCharset } from "./getCharset.ts";
+import type { NextFunction, OpineRequest, OpineResponse } from "../../types.ts";
+import { hasBody, MultipartReader } from "../../../deps.ts";
+import { typeChecker } from "./typeChecker.ts";
+
+/**
+ * Create a middleware to parse formData.
+ *
+ * @param {object} [options]
+ * @return {function}
+ * @public
+ */
+export function formData(options: any = {}) {
+  const defaultCharset = options.defaultCharset || "utf-8";
+  const inflate = options.inflate !== false;
+  const type = options.type || "multipart/form-data";
+  const verify = options.verify || false;
+
+  if (verify !== false && typeof verify !== "function") {
+    throw new TypeError("option verify must be function");
+  }
+
+  // create the appropriate type checking function
+  const shouldParse = typeof type !== "function" ? typeChecker(type) : type;
+
+  return function formParser(
+    req: OpineRequest,
+    res: OpineResponse,
+    next: NextFunction,
+  ) {
+    if (req._parsedBody) {
+      next();
+
+      return;
+    }
+
+    // skip requests without bodies
+    if (
+      !hasBody(req.headers) ||
+      parseInt(req.headers.get("content-length") || "") === 0
+    ) {
+      req.parsedBody = new FormData();
+      req.body = req.parsedBody;
+
+      next();
+
+      return;
+    }
+
+    // determine if request should be parsed
+    if (!shouldParse(req)) {
+      req.parsedBody = new FormData();
+      req.body = req.parsedBody;
+
+      next();
+
+      return;
+    }
+
+    // get charset
+    const charset = getCharset(req) || defaultCharset;
+
+    // read
+    const type = req.headers.get("Content-Type");
+
+    if (!type) {
+      req.parsedBody = new FormData();
+      req.body = req.parsedBody;
+
+      next();
+
+      return;
+    }
+    const mr = new MultipartReader(req.raw, type.split(";")[1]?.split("=")[1]);
+    const body = mr.readForm();
+
+    req._parsedBody = true;
+    req.parsedBody = body;
+    req.body = body;
+    next();
+  };
+}

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -61,9 +61,6 @@ export function formData(options: any = {}) {
     const boundary = type.match(/boundary=(?:([^;]+))/);
 
     if (!boundary) {
-      req.parsedBody = new FormData();
-      req.body = req.parsedBody;
-
       next();
 
       return;

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -66,7 +66,7 @@ export function formData(options: any = {}) {
       return;
     }
 
-    const multipartReader = new MultipartReader(req.raw, boundary[boundary.length - 1]);
+    const multipartReader = new MultipartReader(req.raw, boundary.at(-1) || "");
     const customFormData = new FormData();
 
     const body = await multipartReader.readForm();

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -29,7 +29,6 @@
  *
  */
 
-import { getCharset } from "./getCharset.ts";
 import type { NextFunction, OpineRequest, OpineResponse } from "../../types.ts";
 import { hasBody, MultipartReader } from "../../../deps.ts";
 import { typeChecker } from "./typeChecker.ts";
@@ -42,8 +41,6 @@ import { typeChecker } from "./typeChecker.ts";
  * @public
  */
 export function formData(options: any = {}) {
-  const defaultCharset = options.defaultCharset || "utf-8";
-  const inflate = options.inflate !== false;
   const type = options.type || "multipart/form-data";
   const verify = options.verify || false;
 
@@ -56,7 +53,7 @@ export function formData(options: any = {}) {
 
   return function formParser(
     req: OpineRequest,
-    res: OpineResponse,
+    _res: OpineResponse,
     next: NextFunction,
   ) {
     if (req._parsedBody) {
@@ -80,16 +77,10 @@ export function formData(options: any = {}) {
 
     // determine if request should be parsed
     if (!shouldParse(req)) {
-      req.parsedBody = new FormData();
-      req.body = req.parsedBody;
-
       next();
 
       return;
     }
-
-    // get charset
-    const charset = getCharset(req) || defaultCharset;
 
     // read
     const type = req.headers.get("Content-Type");

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -80,7 +80,7 @@ export function formData(options: any = {}) {
 
     [...body.entries()].forEach(([key, value]) => {
       value?.forEach(async (v) => {
-        if (typeof v == "string") {
+        if (typeof v === "string") {
           customFormData.append(key, v);
         } else {
           let buffer = v.content;

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -62,7 +62,19 @@ export function formData(options: any = {}) {
 
       return;
     }
-    const mr = new MultipartReader(req.raw, type.split(";")[1]?.split("=")[1]);
+
+    const boundary = type.match(/boundary=(?:([^;]+))/);
+
+    if(boundary == null) {
+      req.parsedBody = new FormData();
+      req.body = req.parsedBody;
+
+      next();
+
+      return;
+    }
+
+    const mr = new MultipartReader(req.raw, boundary[boundary.length - 1]);
     const body = mr.readForm();
 
     req._parsedBody = true;

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -47,16 +47,7 @@ export function formData(options: any = {}) {
     }
 
     // read
-    const type = req.headers.get("Content-Type");
-
-    if (!type) {
-      req.parsedBody = new FormData();
-      req.body = req.parsedBody;
-
-      next();
-
-      return;
-    }
+    const type = req.headers.get("Content-Type") || "";
 
     const boundary = type.match(/boundary=(?:([^;]+))/);
 

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -65,7 +65,7 @@ export function formData(options: any = {}) {
 
     const boundary = type.match(/boundary=(?:([^;]+))/);
 
-    if(boundary == null) {
+    if (!boundary) {
       req.parsedBody = new FormData();
       req.body = req.parsedBody;
 

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -1,34 +1,3 @@
-/*!
- * Port of body-parser (https://github.com/expressjs/body-parser) for Deno.
- *
- * Licensed as follows:
- *
- * (The MIT License)
- *
- * Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
- * Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * 'Software'), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- */
-
 import type { NextFunction, OpineRequest, OpineResponse } from "../../types.ts";
 import { hasBody, MultipartReader } from "../../../deps.ts";
 import { typeChecker } from "./typeChecker.ts";

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -70,7 +70,7 @@ export function formData(options: any = {}) {
     const body = await mr.readForm();
     const customFormData = new FormData();
 
-    [...body.entries()].forEach(([key, value]) => {
+    for (const [key, value] of body) {
       value?.forEach(async (v) => {
         if (typeof v === "string") {
           customFormData.append(key, v);
@@ -86,7 +86,7 @@ export function formData(options: any = {}) {
           customFormData.append(key, file);
         }
       });
-    });
+    };
 
     req._parsedBody = true;
     req.parsedBody = customFormData;

--- a/src/middleware/bodyParser/formData.ts
+++ b/src/middleware/bodyParser/formData.ts
@@ -78,7 +78,7 @@ export function formData(options: any = {}) {
           customFormData.append(key, file);
         }
       });
-    };
+    }
 
     req._parsedBody = true;
     req.parsedBody = customFormData;

--- a/test/units/bodyParser.formData.test.ts
+++ b/test/units/bodyParser.formData.test.ts
@@ -2,8 +2,24 @@ import { formData } from "../../mod.ts";
 import { expect } from "../deps.ts";
 import { describe, it } from "../utils.ts";
 
-const mockFormData = new FormData();
+const encoder = new TextEncoder();
+const mockString = "deno formData testing";
 
+const mockFormDataString = `
+--opineBoundary
+Content-Disposition: form-data; name="hello"
+
+deno
+--opineBoundary
+Content-Disposition: form-data; name="file"; filename="file.txt"
+Content-Type: application/octet-stream
+
+${mockString}
+--opineBoundary--
+`.replaceAll(/\n/g, "\r\n");
+
+const mockFormData = new FormData();
+mockFormData.append("file", new File([encoder.encode(mockString)], "file.txt"));
 mockFormData.append("hello", "deno");
 
 const textHeaders = new Headers();
@@ -13,12 +29,56 @@ textHeaders.set("Content-Length", "1");
 const formDataHeaders = new Headers();
 formDataHeaders.set(
   "Content-Type",
-  "multipart/form-data; boundary=----opineBoundary",
+  "multipart/form-data; boundary=opineBoundary",
 );
 
 describe("bodyParser: formData", () => {
   it("should handle requests without bodies", (done) => {
     const req: any = { headers: formDataHeaders };
+    const parser = formData();
+
+    parser(req, {} as any, (err?: any) => {
+      if (err) throw err;
+      expect(req.parsedBody).toEqual(new FormData());
+      done();
+    });
+  });
+
+  it("should handle requests with body", (done) => {
+    const req: any = {
+      headers: formDataHeaders,
+      raw: new Deno.Buffer(encoder.encode(mockFormDataString)),
+    };
+
+    req.headers.set("Content-Length", "1");
+
+    const parser = formData();
+
+    parser(req, {} as any, async (err?: any) => {
+      if (err) throw err;
+
+      const mockFile = (mockFormData.get("file") as File);
+
+      expect(req.parsedBody.get("file").size).toEqual(mockFile.size);
+      expect(req.parsedBody.get("file").name).toEqual(mockFile.name);
+      expect(await req.parsedBody.get("file").text()).toEqual(
+        await mockFile.text(),
+      );
+
+      expect(req.parsedBody.get("hello")).toEqual(mockFormData.get("hello"));
+
+      done();
+    });
+  });
+
+  it("should handle requests without boundary", (done) => {
+    const noBoundaryHeaders = new Headers();
+    noBoundaryHeaders.set(
+      "Content-Type",
+      "multipart/form-data",
+    );
+
+    const req: any = { headers: noBoundaryHeaders };
     const parser = formData();
 
     parser(req, {} as any, (err?: any) => {

--- a/test/units/bodyParser.formData.test.ts
+++ b/test/units/bodyParser.formData.test.ts
@@ -11,7 +11,10 @@ textHeaders.set("Content-Type", "text/plain");
 textHeaders.set("Content-Length", "1");
 
 const formDataHeaders = new Headers();
-formDataHeaders.set("Content-Type", "multipart/form-data; boundary=----opineBoundary");
+formDataHeaders.set(
+  "Content-Type",
+  "multipart/form-data; boundary=----opineBoundary",
+);
 
 describe("bodyParser: formData", () => {
   it("should handle requests without bodies", (done) => {

--- a/test/units/bodyParser.formData.test.ts
+++ b/test/units/bodyParser.formData.test.ts
@@ -1,0 +1,44 @@
+import { formData } from "../../mod.ts";
+import { expect } from "../deps.ts";
+import { describe, it } from "../utils.ts";
+
+const mockFormData = new FormData();
+
+mockFormData.append("hello", "deno");
+
+const textHeaders = new Headers();
+textHeaders.set("Content-Type", "text/plain");
+textHeaders.set("Content-Length", "1");
+
+const formDataHeaders = new Headers();
+formDataHeaders.set("Content-Type", "multipart/form-data; boundary=----opineBoundary");
+
+describe("bodyParser: formData", () => {
+  it("should handle requests without bodies", (done) => {
+    const req: any = { headers: formDataHeaders };
+    const parser = formData();
+
+    parser(req, {} as any, (err?: any) => {
+      if (err) throw err;
+      expect(req.parsedBody).toEqual(new FormData());
+      done();
+    });
+  });
+
+  it("should not alter request bodies when the content type is not multipart", (done) => {
+    const mockBody = Symbol("test-body");
+    const req: any = {
+      body: mockBody,
+      headers: textHeaders,
+    };
+    req.headers.set("Content-Length", "1");
+    const parser = formData();
+
+    parser(req, {} as any, (err?: unknown) => {
+      if (err) throw err;
+      expect(req.body).toEqual(mockBody);
+      expect(req.parsedBody).toBeUndefined();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# Issue

Supersedes #160, fixes #158 and #159

## Details

This is a alternative implementation of #160 which works as a Middleware instead of a property.

## Checklist.

[?] Handle compression
[x] Write tests
[x] Handle proper charsets (not sure if umlauts properly parse 🤷🏽 