### PR TITLE
[#164] Update HTTPSOptions to make it compatible with Deno 1.20.1

### DIFF
--- a/docs/classes/_request_.wrappedrequest.html
+++ b/docs/classes/_request_.wrappedrequest.html
@@ -166,7 +166,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L67">home/runner/work/opine/opine/src/request.ts:67</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L67">home/runner/work/opine/opine/src/request.ts:67</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">#conn<wbr>Info<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ConnInfo</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L40">home/runner/work/opine/opine/src/request.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L40">home/runner/work/opine/opine/src/request.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">#request<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Request</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L39">home/runner/work/opine/opine/src/request.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L39">home/runner/work/opine/opine/src/request.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">#response<wbr>Promise<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Response</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L41">home/runner/work/opine/opine/src/request.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L41">home/runner/work/opine/opine/src/request.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">#response<wbr>Promise<wbr>Resolver<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>response<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Response</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L42">home/runner/work/opine/opine/src/request.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L42">home/runner/work/opine/opine/src/request.ts:42</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -253,7 +253,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#_parsedbody">_parsedBody</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L59">home/runner/work/opine/opine/src/request.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L59">home/runner/work/opine/opine/src/request.ts:59</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -264,7 +264,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#_parsedoriginalurl">_parsedOriginalUrl</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L61">home/runner/work/opine/opine/src/request.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L61">home/runner/work/opine/opine/src/request.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -275,7 +275,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#_parsedurl">_parsedUrl</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L60">home/runner/work/opine/opine/src/request.ts:60</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L60">home/runner/work/opine/opine/src/request.ts:60</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#app">app</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L44">home/runner/work/opine/opine/src/request.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L44">home/runner/work/opine/opine/src/request.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#baseurl">baseUrl</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L52">home/runner/work/opine/opine/src/request.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L52">home/runner/work/opine/opine/src/request.ts:52</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -308,7 +308,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#headers">headers</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L56">home/runner/work/opine/opine/src/request.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L56">home/runner/work/opine/opine/src/request.ts:56</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -319,7 +319,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#method">method</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L55">home/runner/work/opine/opine/src/request.ts:55</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L55">home/runner/work/opine/opine/src/request.ts:55</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -330,7 +330,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#next">next</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L63">home/runner/work/opine/opine/src/request.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L63">home/runner/work/opine/opine/src/request.ts:63</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -341,7 +341,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#originalurl">originalUrl</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L51">home/runner/work/opine/opine/src/request.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L51">home/runner/work/opine/opine/src/request.ts:51</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -352,7 +352,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#param">param</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L64">home/runner/work/opine/opine/src/request.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L64">home/runner/work/opine/opine/src/request.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -387,7 +387,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#params">params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L46">home/runner/work/opine/opine/src/request.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L46">home/runner/work/opine/opine/src/request.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -398,7 +398,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#parsedbody">parsedBody</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L58">home/runner/work/opine/opine/src/request.ts:58</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L58">home/runner/work/opine/opine/src/request.ts:58</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -409,7 +409,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#proto">proto</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L53">home/runner/work/opine/opine/src/request.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L53">home/runner/work/opine/opine/src/request.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -420,7 +420,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#query">query</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L47">home/runner/work/opine/opine/src/request.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L47">home/runner/work/opine/opine/src/request.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -431,7 +431,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#res">res</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L45">home/runner/work/opine/opine/src/request.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L45">home/runner/work/opine/opine/src/request.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -442,7 +442,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#route">route</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L48">home/runner/work/opine/opine/src/request.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L48">home/runner/work/opine/opine/src/request.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -453,7 +453,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#url">url</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L50">home/runner/work/opine/opine/src/request.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L50">home/runner/work/opine/opine/src/request.ts:50</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -470,7 +470,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L309">home/runner/work/opine/opine/src/request.ts:309</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L309">home/runner/work/opine/opine/src/request.ts:309</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -488,7 +488,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L314">home/runner/work/opine/opine/src/request.ts:314</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L314">home/runner/work/opine/opine/src/request.ts:314</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">unknown</span></h4>
@@ -496,7 +496,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L318">home/runner/work/opine/opine/src/request.ts:318</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L318">home/runner/work/opine/opine/src/request.ts:318</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -519,7 +519,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L326">home/runner/work/opine/opine/src/request.ts:326</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L326">home/runner/work/opine/opine/src/request.ts:326</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">ConnInfo</span></h4>
@@ -536,7 +536,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L333">home/runner/work/opine/opine/src/request.ts:333</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L333">home/runner/work/opine/opine/src/request.ts:333</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -558,7 +558,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L498">home/runner/work/opine/opine/src/request.ts:498</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L498">home/runner/work/opine/opine/src/request.ts:498</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -582,7 +582,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L465">home/runner/work/opine/opine/src/request.ts:465</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L465">home/runner/work/opine/opine/src/request.ts:465</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -607,7 +607,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L390">home/runner/work/opine/opine/src/request.ts:390</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L390">home/runner/work/opine/opine/src/request.ts:390</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -631,7 +631,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L407">home/runner/work/opine/opine/src/request.ts:407</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L407">home/runner/work/opine/opine/src/request.ts:407</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -657,7 +657,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L451">home/runner/work/opine/opine/src/request.ts:451</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L451">home/runner/work/opine/opine/src/request.ts:451</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -679,7 +679,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L350">home/runner/work/opine/opine/src/request.ts:350</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L350">home/runner/work/opine/opine/src/request.ts:350</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -707,7 +707,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L322">home/runner/work/opine/opine/src/request.ts:322</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L322">home/runner/work/opine/opine/src/request.ts:322</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>
@@ -724,7 +724,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L376">home/runner/work/opine/opine/src/request.ts:376</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L376">home/runner/work/opine/opine/src/request.ts:376</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -747,7 +747,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L527">home/runner/work/opine/opine/src/request.ts:527</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L527">home/runner/work/opine/opine/src/request.ts:527</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -771,7 +771,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L432">home/runner/work/opine/opine/src/request.ts:432</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L432">home/runner/work/opine/opine/src/request.ts:432</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -799,7 +799,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L537">home/runner/work/opine/opine/src/request.ts:537</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L537">home/runner/work/opine/opine/src/request.ts:537</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -824,7 +824,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L134">home/runner/work/opine/opine/src/request.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L134">home/runner/work/opine/opine/src/request.ts:134</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -889,7 +889,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L148">home/runner/work/opine/opine/src/request.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L148">home/runner/work/opine/opine/src/request.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -921,7 +921,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L165">home/runner/work/opine/opine/src/request.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L165">home/runner/work/opine/opine/src/request.ts:165</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -952,7 +952,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L182">home/runner/work/opine/opine/src/request.ts:182</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L182">home/runner/work/opine/opine/src/request.ts:182</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -984,7 +984,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L214">home/runner/work/opine/opine/src/request.ts:214</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L214">home/runner/work/opine/opine/src/request.ts:214</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1025,7 +1025,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L289">home/runner/work/opine/opine/src/request.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L289">home/runner/work/opine/opine/src/request.ts:289</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1074,7 +1074,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#range">range</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L251">home/runner/work/opine/opine/src/request.ts:251</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L251">home/runner/work/opine/opine/src/request.ts:251</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1116,7 +1116,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L83">home/runner/work/opine/opine/src/request.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L83">home/runner/work/opine/opine/src/request.ts:83</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1140,7 +1140,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opinerequest.html">OpineRequest</a>.<a href="../interfaces/_types_.opinerequest.html#upgrade">upgrade</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L303">home/runner/work/opine/opine/src/request.ts:303</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L303">home/runner/work/opine/opine/src/request.ts:303</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">WebSocket</span></h4>

--- a/docs/classes/_response_.response.html
+++ b/docs/classes/_response_.response.html
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">#resources<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = []</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L49">home/runner/work/opine/opine/src/response.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L49">home/runner/work/opine/opine/src/response.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -158,7 +158,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#app">app</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L45">home/runner/work/opine/opine/src/response.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L45">home/runner/work/opine/opine/src/response.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#body">body</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L44">home/runner/work/opine/opine/src/response.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L44">home/runner/work/opine/opine/src/response.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#headers">headers</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L42">home/runner/work/opine/opine/src/response.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L42">home/runner/work/opine/opine/src/response.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#locals">locals</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L47">home/runner/work/opine/opine/src/response.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L47">home/runner/work/opine/opine/src/response.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#req">req</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L46">home/runner/work/opine/opine/src/response.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L46">home/runner/work/opine/opine/src/response.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L41">home/runner/work/opine/opine/src/response.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L41">home/runner/work/opine/opine/src/response.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -224,7 +224,7 @@
 					<aside class="tsd-sources">
 						<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#written">written</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L43">home/runner/work/opine/opine/src/response.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L43">home/runner/work/opine/opine/src/response.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#addresource">addResource</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L58">home/runner/work/opine/opine/src/response.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L58">home/runner/work/opine/opine/src/response.ts:58</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#append">append</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L77">home/runner/work/opine/opine/src/response.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L77">home/runner/work/opine/opine/src/response.ts:77</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -313,7 +313,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#attachment">attachment</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L96">home/runner/work/opine/opine/src/response.ts:96</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L96">home/runner/work/opine/opine/src/response.ts:96</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -344,7 +344,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#clearcookie">clearCookie</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L154">home/runner/work/opine/opine/src/response.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L154">home/runner/work/opine/opine/src/response.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -365,7 +365,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#clearcookie">clearCookie</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L155">home/runner/work/opine/opine/src/response.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L155">home/runner/work/opine/opine/src/response.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -393,7 +393,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#cookie">cookie</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L118">home/runner/work/opine/opine/src/response.ts:118</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L118">home/runner/work/opine/opine/src/response.ts:118</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -423,7 +423,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#cookie">cookie</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L119">home/runner/work/opine/opine/src/response.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L119">home/runner/work/opine/opine/src/response.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -447,7 +447,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#download">download</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L204">home/runner/work/opine/opine/src/response.ts:204</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L204">home/runner/work/opine/opine/src/response.ts:204</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -488,7 +488,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#end">end</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L247">home/runner/work/opine/opine/src/response.ts:247</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L247">home/runner/work/opine/opine/src/response.ts:247</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -517,7 +517,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#etag">etag</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L289">home/runner/work/opine/opine/src/response.ts:289</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L289">home/runner/work/opine/opine/src/response.ts:289</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -547,7 +547,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#format">format</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L359">home/runner/work/opine/opine/src/response.ts:359</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L359">home/runner/work/opine/opine/src/response.ts:359</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -620,7 +620,7 @@
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#get">get</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L395">home/runner/work/opine/opine/src/response.ts:395</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L395">home/runner/work/opine/opine/src/response.ts:395</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -649,7 +649,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L411">home/runner/work/opine/opine/src/response.ts:411</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L411">home/runner/work/opine/opine/src/response.ts:411</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -682,7 +682,7 @@ res.json({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#x
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L437">home/runner/work/opine/opine/src/response.ts:437</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L437">home/runner/work/opine/opine/src/response.ts:437</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -716,7 +716,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#links">links</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L487">home/runner/work/opine/opine/src/response.ts:487</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L487">home/runner/work/opine/opine/src/response.ts:487</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -751,7 +751,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#location">location</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L517">home/runner/work/opine/opine/src/response.ts:517</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L517">home/runner/work/opine/opine/src/response.ts:517</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -788,7 +788,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#redirect">redirect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L541">home/runner/work/opine/opine/src/response.ts:541</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L541">home/runner/work/opine/opine/src/response.ts:541</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -815,7 +815,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#redirect">redirect</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L542">home/runner/work/opine/opine/src/response.ts:542</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L542">home/runner/work/opine/opine/src/response.ts:542</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -842,7 +842,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#removeheader">removeHeader</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L605">home/runner/work/opine/opine/src/response.ts:605</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L605">home/runner/work/opine/opine/src/response.ts:605</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -874,7 +874,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L622">home/runner/work/opine/opine/src/response.ts:622</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L622">home/runner/work/opine/opine/src/response.ts:622</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -915,7 +915,7 @@ res.jsonp({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L662">home/runner/work/opine/opine/src/response.ts:662</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L662">home/runner/work/opine/opine/src/response.ts:662</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -949,7 +949,7 @@ res.<span class="hljs-built_in">send</span>(<span class="hljs-string">&#x27;&lt;
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#sendfile">sendFile</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L736">home/runner/work/opine/opine/src/response.ts:736</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L736">home/runner/work/opine/opine/src/response.ts:736</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -982,7 +982,7 @@ res.<span class="hljs-built_in">send</span>(<span class="hljs-string">&#x27;&lt;
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#sendstatus">sendStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L795">home/runner/work/opine/opine/src/response.ts:795</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L795">home/runner/work/opine/opine/src/response.ts:795</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1019,7 +1019,7 @@ res.<span class="hljs-built_in">send</span>(<span class="hljs-string">&#x27;&lt;
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#set">set</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L820">home/runner/work/opine/opine/src/response.ts:820</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L820">home/runner/work/opine/opine/src/response.ts:820</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1051,7 +1051,7 @@ res.<span class="hljs-builtin-name">set</span>({
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#set">set</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L821">home/runner/work/opine/opine/src/response.ts:821</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L821">home/runner/work/opine/opine/src/response.ts:821</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1076,7 +1076,7 @@ res.<span class="hljs-builtin-name">set</span>({
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#setheader">setHeader</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L861">home/runner/work/opine/opine/src/response.ts:861</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L861">home/runner/work/opine/opine/src/response.ts:861</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1109,7 +1109,7 @@ res.setHeader({
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#setheader">setHeader</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L862">home/runner/work/opine/opine/src/response.ts:862</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L862">home/runner/work/opine/opine/src/response.ts:862</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1133,7 +1133,7 @@ res.setHeader({
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#setstatus">setStatus</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L877">home/runner/work/opine/opine/src/response.ts:877</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L877">home/runner/work/opine/opine/src/response.ts:877</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1165,7 +1165,7 @@ res.setHeader({
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#type">type</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L898">home/runner/work/opine/opine/src/response.ts:898</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L898">home/runner/work/opine/opine/src/response.ts:898</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1202,7 +1202,7 @@ res.setHeader({
 							<aside class="tsd-sources">
 								<p>Implementation of <a href="../interfaces/_types_.opineresponse.html">OpineResponse</a>.<a href="../interfaces/_types_.opineresponse.html#unset">unset</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L912">home/runner/work/opine/opine/src/response.ts:912</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L912">home/runner/work/opine/opine/src/response.ts:912</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1231,7 +1231,7 @@ res.setHeader({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/response.ts#L926">home/runner/work/opine/opine/src/response.ts:926</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/response.ts#L926">home/runner/work/opine/opine/src/response.ts:926</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_utils_createerror_.httperror.html
+++ b/docs/classes/_utils_createerror_.httperror.html
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L18">home/runner/work/opine/opine/src/utils/createError.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L18">home/runner/work/opine/opine/src/utils/createError.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -158,7 +158,7 @@
 					<div class="tsd-signature tsd-kind-icon">expose<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L17">home/runner/work/opine/opine/src/utils/createError.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L17">home/runner/work/opine/opine/src/utils/createError.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="../interfaces/_utils_createerror_.ierror.html">IError</a>.<a href="../interfaces/_utils_createerror_.ierror.html#message">message</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L14">home/runner/work/opine/opine/src/utils/createError.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L14">home/runner/work/opine/opine/src/utils/createError.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="../interfaces/_utils_createerror_.ierror.html">IError</a>.<a href="../interfaces/_utils_createerror_.ierror.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L13">home/runner/work/opine/opine/src/utils/createError.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L13">home/runner/work/opine/opine/src/utils/createError.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L15">home/runner/work/opine/opine/src/utils/createError.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L15">home/runner/work/opine/opine/src/utils/createError.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L16">home/runner/work/opine/opine/src/utils/createError.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L16">home/runner/work/opine/opine/src/utils/createError.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L56">home/runner/work/opine/opine/src/utils/createError.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L56">home/runner/work/opine/opine/src/utils/createError.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{ </span>message<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>status<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></h4>
@@ -266,7 +266,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L52">home/runner/work/opine/opine/src/utils/createError.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L52">home/runner/work/opine/opine/src/utils/createError.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>

--- a/docs/classes/_utils_createerror_.httperrorimpl.html
+++ b/docs/classes/_utils_createerror_.httperrorimpl.html
@@ -128,7 +128,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#constructor">constructor</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L18">home/runner/work/opine/opine/src/utils/createError.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L18">home/runner/work/opine/opine/src/utils/createError.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -154,7 +154,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#expose">expose</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L17">home/runner/work/opine/opine/src/utils/createError.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L17">home/runner/work/opine/opine/src/utils/createError.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -166,7 +166,7 @@
 						<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#message">message</a></p>
 						<p>Overrides <a href="../interfaces/_utils_createerror_.ierror.html">IError</a>.<a href="../interfaces/_utils_createerror_.ierror.html#message">message</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L14">home/runner/work/opine/opine/src/utils/createError.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L14">home/runner/work/opine/opine/src/utils/createError.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 						<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#name">name</a></p>
 						<p>Overrides <a href="../interfaces/_utils_createerror_.ierror.html">IError</a>.<a href="../interfaces/_utils_createerror_.ierror.html#name">name</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L13">home/runner/work/opine/opine/src/utils/createError.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L13">home/runner/work/opine/opine/src/utils/createError.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#status">status</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L15">home/runner/work/opine/opine/src/utils/createError.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L15">home/runner/work/opine/opine/src/utils/createError.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#statuscode">statusCode</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L16">home/runner/work/opine/opine/src/utils/createError.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L16">home/runner/work/opine/opine/src/utils/createError.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#tojson">toJSON</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L56">home/runner/work/opine/opine/src/utils/createError.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L56">home/runner/work/opine/opine/src/utils/createError.ts:56</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-symbol">{ </span>message<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>status<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></h4>
@@ -258,7 +258,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_utils_createerror_.httperror.html">HttpError</a>.<a href="_utils_createerror_.httperror.html#tostring">toString</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L52">home/runner/work/opine/opine/src/utils/createError.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L52">home/runner/work/opine/opine/src/utils/createError.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>

--- a/docs/classes/_view_.view.html
+++ b/docs/classes/_view_.view.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L35">home/runner/work/opine/opine/src/view.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L35">home/runner/work/opine/opine/src/view.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">default<wbr>Engine<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L30">home/runner/work/opine/opine/src/view.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L30">home/runner/work/opine/opine/src/view.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 					<div class="tsd-signature tsd-kind-icon">engine<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L34">home/runner/work/opine/opine/src/view.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L34">home/runner/work/opine/opine/src/view.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">ext<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L31">home/runner/work/opine/opine/src/view.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L31">home/runner/work/opine/opine/src/view.ts:31</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L32">home/runner/work/opine/opine/src/view.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L32">home/runner/work/opine/opine/src/view.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L35">home/runner/work/opine/opine/src/view.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L35">home/runner/work/opine/opine/src/view.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">root<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L33">home/runner/work/opine/opine/src/view.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L33">home/runner/work/opine/opine/src/view.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L119">home/runner/work/opine/opine/src/view.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L119">home/runner/work/opine/opine/src/view.ts:119</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -254,7 +254,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L141">home/runner/work/opine/opine/src/view.ts:141</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L141">home/runner/work/opine/opine/src/view.ts:141</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -285,7 +285,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L95">home/runner/work/opine/opine/src/view.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L95">home/runner/work/opine/opine/src/view.ts:95</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.application.html
+++ b/docs/interfaces/_types_.application.html
@@ -97,7 +97,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1045">home/runner/work/opine/opine/src/types.ts:1045</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1048">home/runner/work/opine/opine/src/types.ts:1048</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -206,7 +206,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#_params">_params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L192">home/runner/work/opine/opine/src/types.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">_router<span class="tsd-signature-symbol">:</span> <a href="_types_.router.html" class="tsd-signature-type">Router</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1162">home/runner/work/opine/opine/src/types.ts:1162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1165">home/runner/work/opine/opine/src/types.ts:1165</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -232,7 +232,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#all">all</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L136">home/runner/work/opine/opine/src/types.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -248,7 +248,7 @@
 					<div class="tsd-signature tsd-kind-icon">cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1191">home/runner/work/opine/opine/src/types.ts:1191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1194">home/runner/work/opine/opine/src/types.ts:1194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -259,7 +259,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#casesensitive">caseSensitive</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L197">home/runner/work/opine/opine/src/types.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#checkout">checkout</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -281,7 +281,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#connect">connect</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#copy">copy</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L147">home/runner/work/opine/opine/src/types.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -303,7 +303,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#delete">delete</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -313,7 +313,7 @@
 					<div class="tsd-signature tsd-kind-icon">engines<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1195">home/runner/work/opine/opine/src/types.ts:1195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1198">home/runner/work/opine/opine/src/types.ts:1198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -324,7 +324,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#get">get</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1087">home/runner/work/opine/opine/src/types.ts:1087</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1090">home/runner/work/opine/opine/src/types.ts:1090</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#head">head</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -345,7 +345,7 @@
 					<div class="tsd-signature tsd-kind-icon">locals<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1147">home/runner/work/opine/opine/src/types.ts:1147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1150">home/runner/work/opine/opine/src/types.ts:1150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -356,7 +356,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#lock">lock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -367,7 +367,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#m_search">m-search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -378,7 +378,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#merge">merge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -389,7 +389,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mergeparams">mergeParams</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L198">home/runner/work/opine/opine/src/types.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -400,7 +400,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkactivity">mkactivity</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -411,7 +411,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkcol">mkcol</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -421,7 +421,7 @@
 					<div class="tsd-signature tsd-kind-icon">mountpath<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1189">home/runner/work/opine/opine/src/types.ts:1189</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1192">home/runner/work/opine/opine/src/types.ts:1192</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#move">move</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -448,7 +448,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#notify">notify</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -459,7 +459,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#options">options</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -470,7 +470,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#params">params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L191">home/runner/work/opine/opine/src/types.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -480,7 +480,7 @@
 					<div class="tsd-signature tsd-kind-icon">parent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1193">home/runner/work/opine/opine/src/types.ts:1193</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1196">home/runner/work/opine/opine/src/types.ts:1196</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -491,7 +491,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#patch">patch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L144">home/runner/work/opine/opine/src/types.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -502,7 +502,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#post">post</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L138">home/runner/work/opine/opine/src/types.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -513,7 +513,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#propfind">propfind</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -524,7 +524,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#proppatch">proppatch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -535,7 +535,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#purge">purge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -546,7 +546,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#put">put</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -557,7 +557,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#report">report</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -567,7 +567,7 @@
 					<div class="tsd-signature tsd-kind-icon">router<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1143">home/runner/work/opine/opine/src/types.ts:1143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1146">home/runner/work/opine/opine/src/types.ts:1146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -577,7 +577,7 @@
 					<div class="tsd-signature tsd-kind-icon">routes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1157">home/runner/work/opine/opine/src/types.ts:1157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1160">home/runner/work/opine/opine/src/types.ts:1160</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -598,7 +598,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#search">search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -608,7 +608,7 @@
 					<div class="tsd-signature tsd-kind-icon">settings<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1145">home/runner/work/opine/opine/src/types.ts:1145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1148">home/runner/work/opine/opine/src/types.ts:1148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -619,7 +619,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#stack">stack</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L201">home/runner/work/opine/opine/src/types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L204">home/runner/work/opine/opine/src/types.ts:204</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -635,7 +635,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#strict">strict</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L196">home/runner/work/opine/opine/src/types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L199">home/runner/work/opine/opine/src/types.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -646,7 +646,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#subscribe">subscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -657,7 +657,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#trace">trace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L164">home/runner/work/opine/opine/src/types.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -668,7 +668,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unlock">unlock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -679,7 +679,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unsubscribe">unsubscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L166">home/runner/work/opine/opine/src/types.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -690,7 +690,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#use">use</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1164">home/runner/work/opine/opine/src/types.ts:1164</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1167">home/runner/work/opine/opine/src/types.ts:1167</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -707,7 +707,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1067">home/runner/work/opine/opine/src/types.ts:1067</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1070">home/runner/work/opine/opine/src/types.ts:1070</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -729,7 +729,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1130">home/runner/work/opine/opine/src/types.ts:1130</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1133">home/runner/work/opine/opine/src/types.ts:1133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -757,7 +757,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1124">home/runner/work/opine/opine/src/types.ts:1124</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1127">home/runner/work/opine/opine/src/types.ts:1127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -790,7 +790,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1184">home/runner/work/opine/opine/src/types.ts:1184</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1187">home/runner/work/opine/opine/src/types.ts:1187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -824,7 +824,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1127">home/runner/work/opine/opine/src/types.ts:1127</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1130">home/runner/work/opine/opine/src/types.ts:1130</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -852,7 +852,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1112">home/runner/work/opine/opine/src/types.ts:1112</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1115">home/runner/work/opine/opine/src/types.ts:1115</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -885,7 +885,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1201">home/runner/work/opine/opine/src/types.ts:1201</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1204">home/runner/work/opine/opine/src/types.ts:1204</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -963,7 +963,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#handle">handle</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L177">home/runner/work/opine/opine/src/types.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L180">home/runner/work/opine/opine/src/types.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -999,7 +999,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1062">home/runner/work/opine/opine/src/types.ts:1062</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1065">home/runner/work/opine/opine/src/types.ts:1065</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1026,7 +1026,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1075">home/runner/work/opine/opine/src/types.ts:1075</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1078">home/runner/work/opine/opine/src/types.ts:1078</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1054,7 +1054,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1137">home/runner/work/opine/opine/src/types.ts:1137</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1140">home/runner/work/opine/opine/src/types.ts:1140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1068,7 +1068,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1138">home/runner/work/opine/opine/src/types.ts:1138</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1141">home/runner/work/opine/opine/src/types.ts:1141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1097,7 +1097,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1139">home/runner/work/opine/opine/src/types.ts:1139</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1142">home/runner/work/opine/opine/src/types.ts:1142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1126,7 +1126,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1140">home/runner/work/opine/opine/src/types.ts:1140</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1143">home/runner/work/opine/opine/src/types.ts:1143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1155,7 +1155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1141">home/runner/work/opine/opine/src/types.ts:1141</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1144">home/runner/work/opine/opine/src/types.ts:1144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1193,7 +1193,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1175">home/runner/work/opine/opine/src/types.ts:1175</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1178">home/runner/work/opine/opine/src/types.ts:1178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1250,7 +1250,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#param">param</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1088">home/runner/work/opine/opine/src/types.ts:1088</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1091">home/runner/work/opine/opine/src/types.ts:1091</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1276,7 +1276,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1100">home/runner/work/opine/opine/src/types.ts:1100</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1103">home/runner/work/opine/opine/src/types.ts:1103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1305,7 +1305,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#process_params">process_params</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L183">home/runner/work/opine/opine/src/types.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L186">home/runner/work/opine/opine/src/types.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1343,7 +1343,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1221">home/runner/work/opine/opine/src/types.ts:1221</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1224">home/runner/work/opine/opine/src/types.ts:1224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1395,7 +1395,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1226">home/runner/work/opine/opine/src/types.ts:1226</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1229">home/runner/work/opine/opine/src/types.ts:1229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1443,7 +1443,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#route">route</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L167">home/runner/work/opine/opine/src/types.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L170">home/runner/work/opine/opine/src/types.ts:170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1466,7 +1466,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1086">home/runner/work/opine/opine/src/types.ts:1086</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1089">home/runner/work/opine/opine/src/types.ts:1089</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.byterange.html
+++ b/docs/interfaces/_types_.byterange.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">end<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L251">home/runner/work/opine/opine/src/types.ts:251</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L254">home/runner/work/opine/opine/src/types.ts:254</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L250">home/runner/work/opine/opine/src/types.ts:250</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L253">home/runner/work/opine/opine/src/types.ts:253</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_types_.handler.html
+++ b/docs/interfaces/_types_.handler.html
@@ -103,7 +103,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L57">home/runner/work/opine/opine/src/types.ts:57</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L60">home/runner/work/opine/opine/src/types.ts:60</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.iroute.html
+++ b/docs/interfaces/_types_.iroute.html
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">all<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L207">home/runner/work/opine/opine/src/types.ts:207</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L210">home/runner/work/opine/opine/src/types.ts:210</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">checkout<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L216">home/runner/work/opine/opine/src/types.ts:216</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L219">home/runner/work/opine/opine/src/types.ts:219</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">copy<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L217">home/runner/work/opine/opine/src/types.ts:217</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L220">home/runner/work/opine/opine/src/types.ts:220</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">delete<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L211">home/runner/work/opine/opine/src/types.ts:211</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L214">home/runner/work/opine/opine/src/types.ts:214</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">dispatch<span class="tsd-signature-symbol">:</span> <a href="_types_.requesthandler.html" class="tsd-signature-type">RequestHandler</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L233">home/runner/work/opine/opine/src/types.ts:233</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L236">home/runner/work/opine/opine/src/types.ts:236</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L208">home/runner/work/opine/opine/src/types.ts:208</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L211">home/runner/work/opine/opine/src/types.ts:211</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">head<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L214">home/runner/work/opine/opine/src/types.ts:214</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L217">home/runner/work/opine/opine/src/types.ts:217</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">lock<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L218">home/runner/work/opine/opine/src/types.ts:218</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L221">home/runner/work/opine/opine/src/types.ts:221</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">m-<wbr>search<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L223">home/runner/work/opine/opine/src/types.ts:223</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L226">home/runner/work/opine/opine/src/types.ts:226</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">merge<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L219">home/runner/work/opine/opine/src/types.ts:219</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L222">home/runner/work/opine/opine/src/types.ts:222</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">mkactivity<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L220">home/runner/work/opine/opine/src/types.ts:220</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L223">home/runner/work/opine/opine/src/types.ts:223</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -232,7 +232,7 @@
 					<div class="tsd-signature tsd-kind-icon">mkcol<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L221">home/runner/work/opine/opine/src/types.ts:221</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L224">home/runner/work/opine/opine/src/types.ts:224</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -242,7 +242,7 @@
 					<div class="tsd-signature tsd-kind-icon">move<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L222">home/runner/work/opine/opine/src/types.ts:222</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L225">home/runner/work/opine/opine/src/types.ts:225</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -252,7 +252,7 @@
 					<div class="tsd-signature tsd-kind-icon">notify<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L224">home/runner/work/opine/opine/src/types.ts:224</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L227">home/runner/work/opine/opine/src/types.ts:227</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -262,7 +262,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L213">home/runner/work/opine/opine/src/types.ts:213</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L216">home/runner/work/opine/opine/src/types.ts:216</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">patch<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L212">home/runner/work/opine/opine/src/types.ts:212</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L215">home/runner/work/opine/opine/src/types.ts:215</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L205">home/runner/work/opine/opine/src/types.ts:205</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L208">home/runner/work/opine/opine/src/types.ts:208</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<div class="tsd-signature tsd-kind-icon">post<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L209">home/runner/work/opine/opine/src/types.ts:209</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L212">home/runner/work/opine/opine/src/types.ts:212</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -302,7 +302,7 @@
 					<div class="tsd-signature tsd-kind-icon">purge<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L225">home/runner/work/opine/opine/src/types.ts:225</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L228">home/runner/work/opine/opine/src/types.ts:228</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -312,7 +312,7 @@
 					<div class="tsd-signature tsd-kind-icon">put<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L210">home/runner/work/opine/opine/src/types.ts:210</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L213">home/runner/work/opine/opine/src/types.ts:213</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -322,7 +322,7 @@
 					<div class="tsd-signature tsd-kind-icon">report<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L226">home/runner/work/opine/opine/src/types.ts:226</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L229">home/runner/work/opine/opine/src/types.ts:229</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -332,7 +332,7 @@
 					<div class="tsd-signature tsd-kind-icon">search<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L227">home/runner/work/opine/opine/src/types.ts:227</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L230">home/runner/work/opine/opine/src/types.ts:230</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -342,7 +342,7 @@
 					<div class="tsd-signature tsd-kind-icon">stack<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L206">home/runner/work/opine/opine/src/types.ts:206</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L209">home/runner/work/opine/opine/src/types.ts:209</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -352,7 +352,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribe<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L228">home/runner/work/opine/opine/src/types.ts:228</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L231">home/runner/work/opine/opine/src/types.ts:231</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -362,7 +362,7 @@
 					<div class="tsd-signature tsd-kind-icon">trace<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L229">home/runner/work/opine/opine/src/types.ts:229</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L232">home/runner/work/opine/opine/src/types.ts:232</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -372,7 +372,7 @@
 					<div class="tsd-signature tsd-kind-icon">unlock<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L230">home/runner/work/opine/opine/src/types.ts:230</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L233">home/runner/work/opine/opine/src/types.ts:233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -382,7 +382,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsubscribe<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L231">home/runner/work/opine/opine/src/types.ts:231</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L234">home/runner/work/opine/opine/src/types.ts:234</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_types_.irouter.html
+++ b/docs/interfaces/_types_.irouter.html
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">_params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L192">home/runner/work/opine/opine/src/types.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">all<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"all"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L136">home/runner/work/opine/opine/src/types.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -175,7 +175,7 @@
 					<div class="tsd-signature tsd-kind-icon">case<wbr>Sensitive<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L197">home/runner/work/opine/opine/src/types.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -185,7 +185,7 @@
 					<div class="tsd-signature tsd-kind-icon">checkout<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -195,7 +195,7 @@
 					<div class="tsd-signature tsd-kind-icon">connect<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<div class="tsd-signature tsd-kind-icon">copy<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L147">home/runner/work/opine/opine/src/types.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">delete<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"delete"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"get"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L137">home/runner/work/opine/opine/src/types.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">head<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"head"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">lock<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -255,7 +255,7 @@
 					<div class="tsd-signature tsd-kind-icon">m-<wbr>search<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -265,7 +265,7 @@
 					<div class="tsd-signature tsd-kind-icon">merge<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -275,7 +275,7 @@
 					<div class="tsd-signature tsd-kind-icon">merge<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L198">home/runner/work/opine/opine/src/types.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -285,7 +285,7 @@
 					<div class="tsd-signature tsd-kind-icon">mkactivity<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -295,7 +295,7 @@
 					<div class="tsd-signature tsd-kind-icon">mkcol<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -305,7 +305,7 @@
 					<div class="tsd-signature tsd-kind-icon">move<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -315,7 +315,7 @@
 					<div class="tsd-signature tsd-kind-icon">notify<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -325,7 +325,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"options"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -335,7 +335,7 @@
 					<div class="tsd-signature tsd-kind-icon">params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L191">home/runner/work/opine/opine/src/types.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -345,7 +345,7 @@
 					<div class="tsd-signature tsd-kind-icon">patch<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"patch"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L144">home/runner/work/opine/opine/src/types.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -355,7 +355,7 @@
 					<div class="tsd-signature tsd-kind-icon">post<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"post"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L138">home/runner/work/opine/opine/src/types.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -365,7 +365,7 @@
 					<div class="tsd-signature tsd-kind-icon">propfind<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -375,7 +375,7 @@
 					<div class="tsd-signature tsd-kind-icon">proppatch<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -385,7 +385,7 @@
 					<div class="tsd-signature tsd-kind-icon">purge<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -395,7 +395,7 @@
 					<div class="tsd-signature tsd-kind-icon">put<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"put"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -405,7 +405,7 @@
 					<div class="tsd-signature tsd-kind-icon">report<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -415,7 +415,7 @@
 					<div class="tsd-signature tsd-kind-icon">search<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -425,7 +425,7 @@
 					<div class="tsd-signature tsd-kind-icon">stack<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L201">home/runner/work/opine/opine/src/types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L204">home/runner/work/opine/opine/src/types.ts:204</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -440,7 +440,7 @@
 					<div class="tsd-signature tsd-kind-icon">strict<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L196">home/runner/work/opine/opine/src/types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L199">home/runner/work/opine/opine/src/types.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -450,7 +450,7 @@
 					<div class="tsd-signature tsd-kind-icon">subscribe<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -460,7 +460,7 @@
 					<div class="tsd-signature tsd-kind-icon">trace<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L164">home/runner/work/opine/opine/src/types.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -470,7 +470,7 @@
 					<div class="tsd-signature tsd-kind-icon">unlock<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -480,7 +480,7 @@
 					<div class="tsd-signature tsd-kind-icon">unsubscribe<span class="tsd-signature-symbol">:</span> <a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L166">home/runner/work/opine/opine/src/types.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -490,7 +490,7 @@
 					<div class="tsd-signature tsd-kind-icon">use<span class="tsd-signature-symbol">:</span> <a href="_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><a href="_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L168">home/runner/work/opine/opine/src/types.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -507,7 +507,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L177">home/runner/work/opine/opine/src/types.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L180">home/runner/work/opine/opine/src/types.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -543,7 +543,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L178">home/runner/work/opine/opine/src/types.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L181">home/runner/work/opine/opine/src/types.ts:181</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -569,7 +569,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L183">home/runner/work/opine/opine/src/types.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L186">home/runner/work/opine/opine/src/types.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -606,7 +606,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L167">home/runner/work/opine/opine/src/types.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L170">home/runner/work/opine/opine/src/types.ts:170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.irouterhandler.html
+++ b/docs/interfaces/_types_.irouterhandler.html
@@ -93,7 +93,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L126">home/runner/work/opine/opine/src/types.ts:126</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L129">home/runner/work/opine/opine/src/types.ts:129</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -107,7 +107,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L127">home/runner/work/opine/opine/src/types.ts:127</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L130">home/runner/work/opine/opine/src/types.ts:130</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.iroutermatcher.html
+++ b/docs/interfaces/_types_.iroutermatcher.html
@@ -97,7 +97,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L104">home/runner/work/opine/opine/src/types.ts:104</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L107">home/runner/work/opine/opine/src/types.ts:107</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -129,7 +129,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L113">home/runner/work/opine/opine/src/types.ts:113</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L116">home/runner/work/opine/opine/src/types.ts:116</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -161,7 +161,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L122">home/runner/work/opine/opine/src/types.ts:122</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L125">home/runner/work/opine/opine/src/types.ts:125</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.mediatype.html
+++ b/docs/interfaces/_types_.mediatype.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">quality<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L625">home/runner/work/opine/opine/src/types.ts:625</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L628">home/runner/work/opine/opine/src/types.ts:628</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">subtype<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L627">home/runner/work/opine/opine/src/types.ts:627</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L630">home/runner/work/opine/opine/src/types.ts:630</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L626">home/runner/work/opine/opine/src/types.ts:626</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L629">home/runner/work/opine/opine/src/types.ts:629</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L624">home/runner/work/opine/opine/src/types.ts:624</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L627">home/runner/work/opine/opine/src/types.ts:627</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_types_.nextfunction.html
+++ b/docs/interfaces/_types_.nextfunction.html
@@ -85,7 +85,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L35">home/runner/work/opine/opine/src/types.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L38">home/runner/work/opine/opine/src/types.ts:38</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -99,7 +99,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L36">home/runner/work/opine/opine/src/types.ts:36</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L39">home/runner/work/opine/opine/src/types.ts:39</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.opine.html
+++ b/docs/interfaces/_types_.opine.html
@@ -89,7 +89,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1045">home/runner/work/opine/opine/src/types.ts:1045</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1048">home/runner/work/opine/opine/src/types.ts:1048</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#_params">_params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L192">home/runner/work/opine/opine/src/types.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#_router">_router</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1162">home/runner/work/opine/opine/src/types.ts:1162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1165">home/runner/work/opine/opine/src/types.ts:1165</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -227,7 +227,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#all">all</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L136">home/runner/work/opine/opine/src/types.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#cache">cache</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1191">home/runner/work/opine/opine/src/types.ts:1191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1194">home/runner/work/opine/opine/src/types.ts:1194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -255,7 +255,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#casesensitive">caseSensitive</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L197">home/runner/work/opine/opine/src/types.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#checkout">checkout</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#connect">connect</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -288,7 +288,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#copy">copy</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L147">home/runner/work/opine/opine/src/types.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -299,7 +299,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#delete">delete</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -310,7 +310,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#engines">engines</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1195">home/runner/work/opine/opine/src/types.ts:1195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1198">home/runner/work/opine/opine/src/types.ts:1198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -322,7 +322,7 @@
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#get">get</a></p>
 						<p>Overrides <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#get">get</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1087">home/runner/work/opine/opine/src/types.ts:1087</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1090">home/runner/work/opine/opine/src/types.ts:1090</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -333,7 +333,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#head">head</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -344,7 +344,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#locals">locals</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1147">home/runner/work/opine/opine/src/types.ts:1147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1150">home/runner/work/opine/opine/src/types.ts:1150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -355,7 +355,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#lock">lock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -366,7 +366,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#m_search">m-search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -377,7 +377,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#merge">merge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -388,7 +388,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mergeparams">mergeParams</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L198">home/runner/work/opine/opine/src/types.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -399,7 +399,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkactivity">mkactivity</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -410,7 +410,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkcol">mkcol</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -421,7 +421,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#mountpath">mountpath</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1189">home/runner/work/opine/opine/src/types.ts:1189</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1192">home/runner/work/opine/opine/src/types.ts:1192</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#move">move</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -448,7 +448,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#notify">notify</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -459,7 +459,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#options">options</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -470,7 +470,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#params">params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L191">home/runner/work/opine/opine/src/types.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -481,7 +481,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#parent">parent</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1193">home/runner/work/opine/opine/src/types.ts:1193</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1196">home/runner/work/opine/opine/src/types.ts:1196</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -492,7 +492,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#patch">patch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L144">home/runner/work/opine/opine/src/types.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -503,7 +503,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#post">post</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L138">home/runner/work/opine/opine/src/types.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -514,7 +514,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#propfind">propfind</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -525,7 +525,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#proppatch">proppatch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -536,7 +536,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#purge">purge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -547,7 +547,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#put">put</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -558,7 +558,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#report">report</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -568,7 +568,7 @@
 					<div class="tsd-signature tsd-kind-icon">request<span class="tsd-signature-symbol">:</span> <a href="_types_.opinerequest.html" class="tsd-signature-type">OpineRequest</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1230">home/runner/work/opine/opine/src/types.ts:1230</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1233">home/runner/work/opine/opine/src/types.ts:1233</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -578,7 +578,7 @@
 					<div class="tsd-signature tsd-kind-icon">response<span class="tsd-signature-symbol">:</span> <a href="_types_.opineresponse.html" class="tsd-signature-type">OpineResponse</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1231">home/runner/work/opine/opine/src/types.ts:1231</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1234">home/runner/work/opine/opine/src/types.ts:1234</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -589,7 +589,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#router">router</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1143">home/runner/work/opine/opine/src/types.ts:1143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1146">home/runner/work/opine/opine/src/types.ts:1146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -600,7 +600,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#routes">routes</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1157">home/runner/work/opine/opine/src/types.ts:1157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1160">home/runner/work/opine/opine/src/types.ts:1160</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -621,7 +621,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#search">search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -632,7 +632,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#settings">settings</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1145">home/runner/work/opine/opine/src/types.ts:1145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1148">home/runner/work/opine/opine/src/types.ts:1148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -643,7 +643,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#stack">stack</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L201">home/runner/work/opine/opine/src/types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L204">home/runner/work/opine/opine/src/types.ts:204</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -659,7 +659,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#strict">strict</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L196">home/runner/work/opine/opine/src/types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L199">home/runner/work/opine/opine/src/types.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -670,7 +670,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#subscribe">subscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -681,7 +681,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#trace">trace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L164">home/runner/work/opine/opine/src/types.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -692,7 +692,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unlock">unlock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -703,7 +703,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unsubscribe">unsubscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L166">home/runner/work/opine/opine/src/types.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -715,7 +715,7 @@
 						<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#use">use</a></p>
 						<p>Overrides <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#use">use</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1164">home/runner/work/opine/opine/src/types.ts:1164</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1167">home/runner/work/opine/opine/src/types.ts:1167</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -733,7 +733,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#defaultconfiguration">defaultConfiguration</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1067">home/runner/work/opine/opine/src/types.ts:1067</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1070">home/runner/work/opine/opine/src/types.ts:1070</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -756,7 +756,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#disable">disable</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1130">home/runner/work/opine/opine/src/types.ts:1130</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1133">home/runner/work/opine/opine/src/types.ts:1133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -785,7 +785,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#disabled">disabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1124">home/runner/work/opine/opine/src/types.ts:1124</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1127">home/runner/work/opine/opine/src/types.ts:1127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -819,7 +819,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#emit">emit</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1184">home/runner/work/opine/opine/src/types.ts:1184</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1187">home/runner/work/opine/opine/src/types.ts:1187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -854,7 +854,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#enable">enable</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1127">home/runner/work/opine/opine/src/types.ts:1127</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1130">home/runner/work/opine/opine/src/types.ts:1130</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -883,7 +883,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#enabled">enabled</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1112">home/runner/work/opine/opine/src/types.ts:1112</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1115">home/runner/work/opine/opine/src/types.ts:1115</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -917,7 +917,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#engine">engine</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1201">home/runner/work/opine/opine/src/types.ts:1201</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1204">home/runner/work/opine/opine/src/types.ts:1204</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -995,7 +995,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#handle">handle</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L177">home/runner/work/opine/opine/src/types.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L180">home/runner/work/opine/opine/src/types.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1032,7 +1032,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#init">init</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1062">home/runner/work/opine/opine/src/types.ts:1062</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1065">home/runner/work/opine/opine/src/types.ts:1065</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1060,7 +1060,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#lazyrouter">lazyrouter</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1075">home/runner/work/opine/opine/src/types.ts:1075</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1078">home/runner/work/opine/opine/src/types.ts:1078</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1089,7 +1089,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#listen">listen</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1137">home/runner/work/opine/opine/src/types.ts:1137</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1140">home/runner/work/opine/opine/src/types.ts:1140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1104,7 +1104,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#listen">listen</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1138">home/runner/work/opine/opine/src/types.ts:1138</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1141">home/runner/work/opine/opine/src/types.ts:1141</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1134,7 +1134,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#listen">listen</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1139">home/runner/work/opine/opine/src/types.ts:1139</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1142">home/runner/work/opine/opine/src/types.ts:1142</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1164,7 +1164,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#listen">listen</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1140">home/runner/work/opine/opine/src/types.ts:1140</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1143">home/runner/work/opine/opine/src/types.ts:1143</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1194,7 +1194,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#listen">listen</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1141">home/runner/work/opine/opine/src/types.ts:1141</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1144">home/runner/work/opine/opine/src/types.ts:1144</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1233,7 +1233,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#on">on</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1175">home/runner/work/opine/opine/src/types.ts:1175</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1178">home/runner/work/opine/opine/src/types.ts:1178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1291,7 +1291,7 @@
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#param">param</a></p>
 								<p>Overrides <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#param">param</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1088">home/runner/work/opine/opine/src/types.ts:1088</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1091">home/runner/work/opine/opine/src/types.ts:1091</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1318,7 +1318,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#path">path</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1100">home/runner/work/opine/opine/src/types.ts:1100</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1103">home/runner/work/opine/opine/src/types.ts:1103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1347,7 +1347,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#process_params">process_params</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L183">home/runner/work/opine/opine/src/types.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L186">home/runner/work/opine/opine/src/types.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1386,7 +1386,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#render">render</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1221">home/runner/work/opine/opine/src/types.ts:1221</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1224">home/runner/work/opine/opine/src/types.ts:1224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1439,7 +1439,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#render">render</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1226">home/runner/work/opine/opine/src/types.ts:1226</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1229">home/runner/work/opine/opine/src/types.ts:1229</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1487,7 +1487,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#route">route</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L167">home/runner/work/opine/opine/src/types.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L170">home/runner/work/opine/opine/src/types.ts:170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1511,7 +1511,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.application.html">Application</a>.<a href="_types_.application.html#set">set</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1086">home/runner/work/opine/opine/src/types.ts:1086</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1089">home/runner/work/opine/opine/src/types.ts:1089</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.opinerequest.html
+++ b/docs/interfaces/_types_.opinerequest.html
@@ -188,7 +188,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">_parsed<wbr>Body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L588">home/runner/work/opine/opine/src/types.ts:588</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L591">home/runner/work/opine/opine/src/types.ts:591</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -205,7 +205,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">_parsed<wbr>Original<wbr>Url<span class="tsd-signature-symbol">:</span> <a href="../modules/_types_.html#parsedurl" class="tsd-signature-type">ParsedURL</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L607">home/runner/work/opine/opine/src/types.ts:607</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L610">home/runner/work/opine/opine/src/types.ts:610</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">_parsed<wbr>Url<span class="tsd-signature-symbol">:</span> <a href="../modules/_types_.html#parsedurl" class="tsd-signature-type">ParsedURL</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L601">home/runner/work/opine/opine/src/types.ts:601</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L604">home/runner/work/opine/opine/src/types.ts:604</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -237,7 +237,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">app<span class="tsd-signature-symbol">:</span> <a href="_types_.application.html" class="tsd-signature-type">Application</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L574">home/runner/work/opine/opine/src/types.ts:574</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L577">home/runner/work/opine/opine/src/types.ts:577</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">base<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L567">home/runner/work/opine/opine/src/types.ts:567</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L570">home/runner/work/opine/opine/src/types.ts:570</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L548">home/runner/work/opine/opine/src/types.ts:548</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L551">home/runner/work/opine/opine/src/types.ts:551</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">conn<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ConnInfo</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L572">home/runner/work/opine/opine/src/types.ts:572</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L575">home/runner/work/opine/opine/src/types.ts:575</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">final<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Response</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L620">home/runner/work/opine/opine/src/types.ts:620</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L623">home/runner/work/opine/opine/src/types.ts:623</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -302,7 +302,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">fresh<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L524">home/runner/work/opine/opine/src/types.ts:524</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L527">home/runner/work/opine/opine/src/types.ts:527</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@ app.get&lt;ParamsArray&gt;(<span class="hljs-string">&#x27;/user/*&#x27;</span>,
 					<div class="tsd-signature tsd-kind-icon">get<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L400">home/runner/work/opine/opine/src/types.ts:400</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L403">home/runner/work/opine/opine/src/types.ts:403</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Headers</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L570">home/runner/work/opine/opine/src/types.ts:570</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L573">home/runner/work/opine/opine/src/types.ts:573</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -377,7 +377,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">hostname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L517">home/runner/work/opine/opine/src/types.ts:517</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L520">home/runner/work/opine/opine/src/types.ts:520</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -392,7 +392,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">ip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L484">home/runner/work/opine/opine/src/types.ts:484</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L487">home/runner/work/opine/opine/src/types.ts:487</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -409,7 +409,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">ips<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L494">home/runner/work/opine/opine/src/types.ts:494</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L497">home/runner/work/opine/opine/src/types.ts:497</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -428,7 +428,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L555">home/runner/work/opine/opine/src/types.ts:555</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L558">home/runner/work/opine/opine/src/types.ts:558</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -438,7 +438,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">next<span class="tsd-signature-symbol">:</span> <a href="_types_.nextfunction.html" class="tsd-signature-type">NextFunction</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L581">home/runner/work/opine/opine/src/types.ts:581</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L584">home/runner/work/opine/opine/src/types.ts:584</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -448,7 +448,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">original<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L563">home/runner/work/opine/opine/src/types.ts:563</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L566">home/runner/work/opine/opine/src/types.ts:566</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -458,7 +458,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">param<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, defaultValue<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L401">home/runner/work/opine/opine/src/types.ts:401</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L404">home/runner/work/opine/opine/src/types.ts:404</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -492,7 +492,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">P</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L557">home/runner/work/opine/opine/src/types.ts:557</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L560">home/runner/work/opine/opine/src/types.ts:560</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -502,7 +502,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">parsed<wbr>Body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L595">home/runner/work/opine/opine/src/types.ts:595</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L598">home/runner/work/opine/opine/src/types.ts:598</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -519,7 +519,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L512">home/runner/work/opine/opine/src/types.ts:512</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L515">home/runner/work/opine/opine/src/types.ts:515</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -534,7 +534,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">proto<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L569">home/runner/work/opine/opine/src/types.ts:569</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L572">home/runner/work/opine/opine/src/types.ts:572</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -544,7 +544,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">protocol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L470">home/runner/work/opine/opine/src/types.ts:470</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L473">home/runner/work/opine/opine/src/types.ts:473</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -564,7 +564,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">query<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ReqQuery</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L559">home/runner/work/opine/opine/src/types.ts:559</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L562">home/runner/work/opine/opine/src/types.ts:562</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -574,7 +574,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">raw<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Deno.Reader</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L553">home/runner/work/opine/opine/src/types.ts:553</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L556">home/runner/work/opine/opine/src/types.ts:556</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -589,7 +589,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">res<span class="tsd-signature-symbol">:</span> <a href="_types_.opineresponse.html" class="tsd-signature-type">OpineResponse</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L580">home/runner/work/opine/opine/src/types.ts:580</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L583">home/runner/work/opine/opine/src/types.ts:583</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -605,7 +605,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">route<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L561">home/runner/work/opine/opine/src/types.ts:561</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L564">home/runner/work/opine/opine/src/types.ts:564</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -615,7 +615,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">secure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L477">home/runner/work/opine/opine/src/types.ts:477</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L480">home/runner/work/opine/opine/src/types.ts:480</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -631,7 +631,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">stale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L531">home/runner/work/opine/opine/src/types.ts:531</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L534">home/runner/work/opine/opine/src/types.ts:534</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -648,7 +648,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">subdomains<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L507">home/runner/work/opine/opine/src/types.ts:507</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L510">home/runner/work/opine/opine/src/types.ts:510</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -669,7 +669,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L565">home/runner/work/opine/opine/src/types.ts:565</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L568">home/runner/work/opine/opine/src/types.ts:568</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -679,7 +679,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 					<div class="tsd-signature tsd-kind-icon">xhr<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L536">home/runner/work/opine/opine/src/types.ts:536</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L539">home/runner/work/opine/opine/src/types.ts:539</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -704,7 +704,7 @@ req.get(<span class="hljs-string">&#x27;Something&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L342">home/runner/work/opine/opine/src/types.ts:342</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L345">home/runner/work/opine/opine/src/types.ts:345</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -749,7 +749,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L343">home/runner/work/opine/opine/src/types.ts:343</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L346">home/runner/work/opine/opine/src/types.ts:346</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -763,7 +763,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L344">home/runner/work/opine/opine/src/types.ts:344</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L347">home/runner/work/opine/opine/src/types.ts:347</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -777,7 +777,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L345">home/runner/work/opine/opine/src/types.ts:345</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L348">home/runner/work/opine/opine/src/types.ts:348</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -803,7 +803,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L354">home/runner/work/opine/opine/src/types.ts:354</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L357">home/runner/work/opine/opine/src/types.ts:357</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -819,7 +819,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L355">home/runner/work/opine/opine/src/types.ts:355</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L358">home/runner/work/opine/opine/src/types.ts:358</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -833,7 +833,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L356">home/runner/work/opine/opine/src/types.ts:356</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L359">home/runner/work/opine/opine/src/types.ts:359</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -847,7 +847,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L357">home/runner/work/opine/opine/src/types.ts:357</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L360">home/runner/work/opine/opine/src/types.ts:360</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -873,7 +873,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L366">home/runner/work/opine/opine/src/types.ts:366</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L369">home/runner/work/opine/opine/src/types.ts:369</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -889,7 +889,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L367">home/runner/work/opine/opine/src/types.ts:367</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L370">home/runner/work/opine/opine/src/types.ts:370</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -903,7 +903,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L368">home/runner/work/opine/opine/src/types.ts:368</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L371">home/runner/work/opine/opine/src/types.ts:371</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -917,7 +917,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L369">home/runner/work/opine/opine/src/types.ts:369</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L372">home/runner/work/opine/opine/src/types.ts:372</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -943,7 +943,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L378">home/runner/work/opine/opine/src/types.ts:378</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L381">home/runner/work/opine/opine/src/types.ts:381</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -959,7 +959,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L379">home/runner/work/opine/opine/src/types.ts:379</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L382">home/runner/work/opine/opine/src/types.ts:382</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -973,7 +973,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L380">home/runner/work/opine/opine/src/types.ts:380</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L383">home/runner/work/opine/opine/src/types.ts:383</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -987,7 +987,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L381">home/runner/work/opine/opine/src/types.ts:381</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L384">home/runner/work/opine/opine/src/types.ts:384</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1010,7 +1010,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L441">home/runner/work/opine/opine/src/types.ts:441</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L444">home/runner/work/opine/opine/src/types.ts:444</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1055,7 +1055,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L415">home/runner/work/opine/opine/src/types.ts:415</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L418">home/runner/work/opine/opine/src/types.ts:418</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1093,7 +1093,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L609">home/runner/work/opine/opine/src/types.ts:609</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L612">home/runner/work/opine/opine/src/types.ts:612</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1145,7 +1145,7 @@ req.accepts(<span class="hljs-string">&#x27;html, json&#x27;</span>);
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L460">home/runner/work/opine/opine/src/types.ts:460</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L463">home/runner/work/opine/opine/src/types.ts:463</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.opineresponse.html
+++ b/docs/interfaces/_types_.opineresponse.html
@@ -154,7 +154,7 @@
 					<div class="tsd-signature tsd-kind-icon">app<span class="tsd-signature-symbol">:</span> <a href="_types_.application.html" class="tsd-signature-type">Application</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L640">home/runner/work/opine/opine/src/types.ts:640</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L643">home/runner/work/opine/opine/src/types.ts:643</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Deno.Reader</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L638">home/runner/work/opine/opine/src/types.ts:638</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L641">home/runner/work/opine/opine/src/types.ts:641</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">headers<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Headers</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L637">home/runner/work/opine/opine/src/types.ts:637</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L640">home/runner/work/opine/opine/src/types.ts:640</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">json<span class="tsd-signature-symbol">:</span> <a href="../modules/_types_.html#send" class="tsd-signature-type">Send</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L804">home/runner/work/opine/opine/src/types.ts:804</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L807">home/runner/work/opine/opine/src/types.ts:807</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -205,7 +205,7 @@ res.setStatus(<span class="hljs-number">404</span>).json(`I don<span class="hljs
 					<div class="tsd-signature tsd-kind-icon">jsonp<span class="tsd-signature-symbol">:</span> <a href="../modules/_types_.html#send" class="tsd-signature-type">Send</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L816">home/runner/work/opine/opine/src/types.ts:816</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L819">home/runner/work/opine/opine/src/types.ts:819</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@ res.setStatus(<span class="hljs-number">404</span>).json(`I don<span class="hljs
 					<div class="tsd-signature tsd-kind-icon">locals<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L644">home/runner/work/opine/opine/src/types.ts:644</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L647">home/runner/work/opine/opine/src/types.ts:647</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@ res.setStatus(<span class="hljs-number">404</span>).json(`I don<span class="hljs
 					<div class="tsd-signature tsd-kind-icon">req<span class="tsd-signature-symbol">:</span> <a href="_types_.opinerequest.html" class="tsd-signature-type">OpineRequest</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L642">home/runner/work/opine/opine/src/types.ts:642</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L645">home/runner/work/opine/opine/src/types.ts:645</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -246,7 +246,7 @@ res.setStatus(<span class="hljs-number">404</span>).json(`I don<span class="hljs
 					<div class="tsd-signature tsd-kind-icon">send<span class="tsd-signature-symbol">:</span> <a href="../modules/_types_.html#send" class="tsd-signature-type">Send</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">this</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L917">home/runner/work/opine/opine/src/types.ts:917</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L920">home/runner/work/opine/opine/src/types.ts:920</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -267,7 +267,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L635">home/runner/work/opine/opine/src/types.ts:635</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L638">home/runner/work/opine/opine/src/types.ts:638</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -277,7 +277,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Message<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L646">home/runner/work/opine/opine/src/types.ts:646</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L649">home/runner/work/opine/opine/src/types.ts:649</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -287,7 +287,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L636">home/runner/work/opine/opine/src/types.ts:636</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L639">home/runner/work/opine/opine/src/types.ts:639</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -297,7 +297,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 					<div class="tsd-signature tsd-kind-icon">written<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L651">home/runner/work/opine/opine/src/types.ts:651</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L654">home/runner/work/opine/opine/src/types.ts:654</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L657">home/runner/work/opine/opine/src/types.ts:657</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L660">home/runner/work/opine/opine/src/types.ts:660</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -348,7 +348,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L672">home/runner/work/opine/opine/src/types.ts:672</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L675">home/runner/work/opine/opine/src/types.ts:675</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -386,7 +386,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L677">home/runner/work/opine/opine/src/types.ts:677</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L680">home/runner/work/opine/opine/src/types.ts:680</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -415,7 +415,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L691">home/runner/work/opine/opine/src/types.ts:691</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L694">home/runner/work/opine/opine/src/types.ts:694</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -437,7 +437,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L696">home/runner/work/opine/opine/src/types.ts:696</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L699">home/runner/work/opine/opine/src/types.ts:699</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -466,7 +466,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L687">home/runner/work/opine/opine/src/types.ts:687</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L690">home/runner/work/opine/opine/src/types.ts:690</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -488,7 +488,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L688">home/runner/work/opine/opine/src/types.ts:688</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L691">home/runner/work/opine/opine/src/types.ts:691</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -519,7 +519,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L711">home/runner/work/opine/opine/src/types.ts:711</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L714">home/runner/work/opine/opine/src/types.ts:714</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -544,7 +544,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L712">home/runner/work/opine/opine/src/types.ts:712</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L715">home/runner/work/opine/opine/src/types.ts:715</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -561,7 +561,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L713">home/runner/work/opine/opine/src/types.ts:713</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L716">home/runner/work/opine/opine/src/types.ts:716</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -591,7 +591,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L734">home/runner/work/opine/opine/src/types.ts:734</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L737">home/runner/work/opine/opine/src/types.ts:737</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -613,7 +613,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L735">home/runner/work/opine/opine/src/types.ts:735</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L738">home/runner/work/opine/opine/src/types.ts:738</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -636,7 +636,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L718">home/runner/work/opine/opine/src/types.ts:718</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L721">home/runner/work/opine/opine/src/types.ts:721</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -664,7 +664,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L789">home/runner/work/opine/opine/src/types.ts:789</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L792">home/runner/work/opine/opine/src/types.ts:792</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -735,7 +735,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L792">home/runner/work/opine/opine/src/types.ts:792</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L795">home/runner/work/opine/opine/src/types.ts:795</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -763,7 +763,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L828">home/runner/work/opine/opine/src/types.ts:828</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L831">home/runner/work/opine/opine/src/types.ts:831</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -796,7 +796,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L856">home/runner/work/opine/opine/src/types.ts:856</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L859">home/runner/work/opine/opine/src/types.ts:859</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -842,7 +842,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L875">home/runner/work/opine/opine/src/types.ts:875</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L878">home/runner/work/opine/opine/src/types.ts:878</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -868,7 +868,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L876">home/runner/work/opine/opine/src/types.ts:876</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L879">home/runner/work/opine/opine/src/types.ts:879</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -894,7 +894,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L888">home/runner/work/opine/opine/src/types.ts:888</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L891">home/runner/work/opine/opine/src/types.ts:891</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -927,7 +927,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L900">home/runner/work/opine/opine/src/types.ts:900</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L903">home/runner/work/opine/opine/src/types.ts:903</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -980,7 +980,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L905">home/runner/work/opine/opine/src/types.ts:905</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L908">home/runner/work/opine/opine/src/types.ts:908</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1027,7 +1027,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L944">home/runner/work/opine/opine/src/types.ts:944</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L947">home/runner/work/opine/opine/src/types.ts:947</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1077,7 +1077,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L956">home/runner/work/opine/opine/src/types.ts:956</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L959">home/runner/work/opine/opine/src/types.ts:959</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1111,7 +1111,7 @@ res.setStatus(<span class="hljs-number">404</span>).<span class="hljs-built_in">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L970">home/runner/work/opine/opine/src/types.ts:970</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L973">home/runner/work/opine/opine/src/types.ts:973</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1141,7 +1141,7 @@ res.<span class="hljs-builtin-name">set</span>({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L971">home/runner/work/opine/opine/src/types.ts:971</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L974">home/runner/work/opine/opine/src/types.ts:974</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1165,7 +1165,7 @@ res.<span class="hljs-builtin-name">set</span>({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L991">home/runner/work/opine/opine/src/types.ts:991</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L994">home/runner/work/opine/opine/src/types.ts:994</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1197,7 +1197,7 @@ res.setHeader({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L992">home/runner/work/opine/opine/src/types.ts:992</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L995">home/runner/work/opine/opine/src/types.ts:995</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1220,7 +1220,7 @@ res.setHeader({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L997">home/runner/work/opine/opine/src/types.ts:997</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1000">home/runner/work/opine/opine/src/types.ts:1000</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1248,7 +1248,7 @@ res.setHeader({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1010">home/runner/work/opine/opine/src/types.ts:1010</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1013">home/runner/work/opine/opine/src/types.ts:1013</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1283,7 +1283,7 @@ res.setHeader({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1019">home/runner/work/opine/opine/src/types.ts:1019</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1022">home/runner/work/opine/opine/src/types.ts:1022</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1313,7 +1313,7 @@ res.setHeader({
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1027">home/runner/work/opine/opine/src/types.ts:1027</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1030">home/runner/work/opine/opine/src/types.ts:1030</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.rangeparseroptions.html
+++ b/docs/interfaces/_types_.rangeparseroptions.html
@@ -96,7 +96,7 @@
 					<div class="tsd-signature tsd-kind-icon">combine<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L278">home/runner/work/opine/opine/src/types.ts:278</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L281">home/runner/work/opine/opine/src/types.ts:281</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/_types_.rangeparserrange.html
+++ b/docs/interfaces/_types_.rangeparserrange.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">end<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L266">home/runner/work/opine/opine/src/types.ts:266</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L269">home/runner/work/opine/opine/src/types.ts:269</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -107,7 +107,7 @@
 					<div class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L265">home/runner/work/opine/opine/src/types.ts:265</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L268">home/runner/work/opine/opine/src/types.ts:268</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_types_.rangeparserranges.html
+++ b/docs/interfaces/_types_.rangeparserranges.html
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L270">home/runner/work/opine/opine/src/types.ts:270</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L273">home/runner/work/opine/opine/src/types.ts:273</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_types_.requesthandler.html
+++ b/docs/interfaces/_types_.requesthandler.html
@@ -106,7 +106,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L57">home/runner/work/opine/opine/src/types.ts:57</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L60">home/runner/work/opine/opine/src/types.ts:60</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.router.html
+++ b/docs/interfaces/_types_.router.html
@@ -106,7 +106,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L57">home/runner/work/opine/opine/src/types.ts:57</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L60">home/runner/work/opine/opine/src/types.ts:60</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -189,7 +189,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#_params">_params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L192">home/runner/work/opine/opine/src/types.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#all">all</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L136">home/runner/work/opine/opine/src/types.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -217,7 +217,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#casesensitive">caseSensitive</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L197">home/runner/work/opine/opine/src/types.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -228,7 +228,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#checkout">checkout</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#connect">connect</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -250,7 +250,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#copy">copy</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L147">home/runner/work/opine/opine/src/types.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -261,7 +261,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#delete">delete</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#get">get</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L137">home/runner/work/opine/opine/src/types.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -283,7 +283,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#head">head</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -294,7 +294,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#lock">lock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -305,7 +305,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#m_search">m-search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#merge">merge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -327,7 +327,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mergeparams">mergeParams</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L198">home/runner/work/opine/opine/src/types.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -338,7 +338,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkactivity">mkactivity</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -349,7 +349,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkcol">mkcol</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -360,7 +360,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#move">move</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -371,7 +371,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#notify">notify</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -382,7 +382,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#options">options</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -393,7 +393,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#params">params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L191">home/runner/work/opine/opine/src/types.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -404,7 +404,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#patch">patch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L144">home/runner/work/opine/opine/src/types.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -415,7 +415,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#post">post</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L138">home/runner/work/opine/opine/src/types.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -426,7 +426,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#propfind">propfind</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -437,7 +437,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#proppatch">proppatch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -448,7 +448,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#purge">purge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -459,7 +459,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#put">put</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -470,7 +470,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#report">report</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -481,7 +481,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#search">search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -492,7 +492,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#stack">stack</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L201">home/runner/work/opine/opine/src/types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L204">home/runner/work/opine/opine/src/types.ts:204</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -508,7 +508,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#strict">strict</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L196">home/runner/work/opine/opine/src/types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L199">home/runner/work/opine/opine/src/types.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -519,7 +519,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#subscribe">subscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -530,7 +530,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#trace">trace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L164">home/runner/work/opine/opine/src/types.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -541,7 +541,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unlock">unlock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -552,7 +552,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unsubscribe">unsubscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L166">home/runner/work/opine/opine/src/types.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -563,7 +563,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#use">use</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L168">home/runner/work/opine/opine/src/types.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -581,7 +581,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#handle">handle</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L177">home/runner/work/opine/opine/src/types.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L180">home/runner/work/opine/opine/src/types.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -618,7 +618,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#param">param</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L178">home/runner/work/opine/opine/src/types.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L181">home/runner/work/opine/opine/src/types.ts:181</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -645,7 +645,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#process_params">process_params</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L183">home/runner/work/opine/opine/src/types.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L186">home/runner/work/opine/opine/src/types.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -683,7 +683,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#route">route</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L167">home/runner/work/opine/opine/src/types.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L170">home/runner/work/opine/opine/src/types.ts:170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.routerconstructor.html
+++ b/docs/interfaces/_types_.routerconstructor.html
@@ -89,7 +89,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L245">home/runner/work/opine/opine/src/types.ts:245</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L248">home/runner/work/opine/opine/src/types.ts:248</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L244">home/runner/work/opine/opine/src/types.ts:244</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L247">home/runner/work/opine/opine/src/types.ts:247</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -198,7 +198,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#_params">_params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L192">home/runner/work/opine/opine/src/types.ts:192</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#all">all</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L136">home/runner/work/opine/opine/src/types.ts:136</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#casesensitive">caseSensitive</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L197">home/runner/work/opine/opine/src/types.ts:197</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -237,7 +237,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#checkout">checkout</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -248,7 +248,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#connect">connect</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -259,7 +259,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#copy">copy</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L147">home/runner/work/opine/opine/src/types.ts:147</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -270,7 +270,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#delete">delete</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -281,7 +281,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#get">get</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L137">home/runner/work/opine/opine/src/types.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L140">home/runner/work/opine/opine/src/types.ts:140</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -292,7 +292,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#head">head</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L143">home/runner/work/opine/opine/src/types.ts:143</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L146">home/runner/work/opine/opine/src/types.ts:146</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -303,7 +303,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#lock">lock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L148">home/runner/work/opine/opine/src/types.ts:148</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -314,7 +314,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#m_search">m-search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -325,7 +325,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#merge">merge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L149">home/runner/work/opine/opine/src/types.ts:149</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -336,7 +336,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mergeparams">mergeParams</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L195">home/runner/work/opine/opine/src/types.ts:195</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L198">home/runner/work/opine/opine/src/types.ts:198</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -347,7 +347,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkactivity">mkactivity</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L150">home/runner/work/opine/opine/src/types.ts:150</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L153">home/runner/work/opine/opine/src/types.ts:153</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -358,7 +358,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#mkcol">mkcol</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L151">home/runner/work/opine/opine/src/types.ts:151</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -369,7 +369,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#move">move</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L152">home/runner/work/opine/opine/src/types.ts:152</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -380,7 +380,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#notify">notify</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L154">home/runner/work/opine/opine/src/types.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -391,7 +391,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#options">options</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L145">home/runner/work/opine/opine/src/types.ts:145</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -402,7 +402,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#params">params</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L191">home/runner/work/opine/opine/src/types.ts:191</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L194">home/runner/work/opine/opine/src/types.ts:194</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -413,7 +413,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#patch">patch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L144">home/runner/work/opine/opine/src/types.ts:144</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -424,7 +424,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#post">post</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L138">home/runner/work/opine/opine/src/types.ts:138</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L141">home/runner/work/opine/opine/src/types.ts:141</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -435,7 +435,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#propfind">propfind</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L155">home/runner/work/opine/opine/src/types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -446,7 +446,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#proppatch">proppatch</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L156">home/runner/work/opine/opine/src/types.ts:156</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -457,7 +457,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#purge">purge</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L157">home/runner/work/opine/opine/src/types.ts:157</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -468,7 +468,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#put">put</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L139">home/runner/work/opine/opine/src/types.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L142">home/runner/work/opine/opine/src/types.ts:142</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -479,7 +479,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#report">report</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L158">home/runner/work/opine/opine/src/types.ts:158</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -490,7 +490,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#search">search</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L159">home/runner/work/opine/opine/src/types.ts:159</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -501,7 +501,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#stack">stack</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L201">home/runner/work/opine/opine/src/types.ts:201</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L204">home/runner/work/opine/opine/src/types.ts:204</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -517,7 +517,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#strict">strict</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L196">home/runner/work/opine/opine/src/types.ts:196</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L199">home/runner/work/opine/opine/src/types.ts:199</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -528,7 +528,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#subscribe">subscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L160">home/runner/work/opine/opine/src/types.ts:160</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -539,7 +539,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#trace">trace</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L161">home/runner/work/opine/opine/src/types.ts:161</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L164">home/runner/work/opine/opine/src/types.ts:164</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -550,7 +550,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unlock">unlock</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L162">home/runner/work/opine/opine/src/types.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -561,7 +561,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#unsubscribe">unsubscribe</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L163">home/runner/work/opine/opine/src/types.ts:163</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L166">home/runner/work/opine/opine/src/types.ts:166</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -572,7 +572,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#use">use</a></p>
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L165">home/runner/work/opine/opine/src/types.ts:165</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L168">home/runner/work/opine/opine/src/types.ts:168</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -590,7 +590,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#handle">handle</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L177">home/runner/work/opine/opine/src/types.ts:177</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L180">home/runner/work/opine/opine/src/types.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -627,7 +627,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#param">param</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L178">home/runner/work/opine/opine/src/types.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L181">home/runner/work/opine/opine/src/types.ts:181</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -654,7 +654,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#process_params">process_params</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L183">home/runner/work/opine/opine/src/types.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L186">home/runner/work/opine/opine/src/types.ts:186</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -692,7 +692,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="_types_.irouter.html">IRouter</a>.<a href="_types_.irouter.html#route">route</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L167">home/runner/work/opine/opine/src/types.ts:167</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L170">home/runner/work/opine/opine/src/types.ts:170</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_types_.routeroptions.html
+++ b/docs/interfaces/_types_.routeroptions.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">case<wbr>Sensitive<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L239">home/runner/work/opine/opine/src/types.ts:239</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L242">home/runner/work/opine/opine/src/types.ts:242</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">merge<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L240">home/runner/work/opine/opine/src/types.ts:240</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L243">home/runner/work/opine/opine/src/types.ts:243</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">strict<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L241">home/runner/work/opine/opine/src/types.ts:241</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L244">home/runner/work/opine/opine/src/types.ts:244</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_utils_createerror_.ierror.html
+++ b/docs/interfaces/_utils_createerror_.ierror.html
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">expose<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L74">home/runner/work/opine/opine/src/utils/createError.ts:74</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L74">home/runner/work/opine/opine/src/utils/createError.ts:74</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -164,7 +164,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L72">home/runner/work/opine/opine/src/utils/createError.ts:72</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L72">home/runner/work/opine/opine/src/utils/createError.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L73">home/runner/work/opine/opine/src/utils/createError.ts:73</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L73">home/runner/work/opine/opine/src/utils/createError.ts:73</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_application_.html
+++ b/docs/modules/_application_.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">app<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.application.html" class="tsd-signature-type">Application</a><span class="tsd-signature-symbol"> = {} as Application</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L41">home/runner/work/opine/opine/src/application.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L41">home/runner/work/opine/opine/src/application.ts:41</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">create</span><span class="tsd-signature-symbol"> = Object.create</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L26">home/runner/work/opine/opine/src/application.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L26">home/runner/work/opine/opine/src/application.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>Prototype<wbr>Of<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = Object.setPrototypeOf</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L27">home/runner/work/opine/opine/src/application.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L27">home/runner/work/opine/opine/src/application.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">slice<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.rangeparserranges.html#slice" class="tsd-signature-type">slice</a><span class="tsd-signature-symbol"> = Array.prototype.slice</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L28">home/runner/work/opine/opine/src/application.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L28">home/runner/work/opine/opine/src/application.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">trust<wbr>Proxy<wbr>Default<wbr>Symbol<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@symbol:trust_proxy_default"</span><span class="tsd-signature-symbol"> = &quot;@@symbol:trust_proxy_default&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L34">home/runner/work/opine/opine/src/application.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L34">home/runner/work/opine/opine/src/application.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L155">home/runner/work/opine/opine/src/application.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L155">home/runner/work/opine/opine/src/application.ts:155</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -187,7 +187,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L536">home/runner/work/opine/opine/src/application.ts:536</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L536">home/runner/work/opine/opine/src/application.ts:536</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/application.ts#L436">home/runner/work/opine/opine/src/application.ts:436</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/application.ts#L436">home/runner/work/opine/opine/src/application.ts:436</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_methods_.html
+++ b/docs/modules/_methods_.html
@@ -85,7 +85,7 @@
 					<div class="tsd-signature tsd-kind-icon">methods<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&quot;get&quot;,&quot;post&quot;,&quot;put&quot;,&quot;head&quot;,&quot;delete&quot;,&quot;options&quot;,// &quot;trace&quot;, // As of Deno 1.9.0 - TypeError: Method is forbidden.&quot;copy&quot;,&quot;lock&quot;,&quot;mkcol&quot;,&quot;move&quot;,&quot;purge&quot;,&quot;propfind&quot;,&quot;proppatch&quot;,&quot;unlock&quot;,&quot;report&quot;,&quot;mkactivity&quot;,&quot;checkout&quot;,&quot;merge&quot;,&quot;m-search&quot;,&quot;notify&quot;,&quot;subscribe&quot;,&quot;unsubscribe&quot;,&quot;patch&quot;,&quot;search&quot;,&quot;connect&quot;,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/methods.ts#L6">home/runner/work/opine/opine/src/methods.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/methods.ts#L6">home/runner/work/opine/opine/src/methods.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_getcharset_.html
+++ b/docs/modules/_middleware_bodyparser_getcharset_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/getCharset.ts#L11">home/runner/work/opine/opine/src/middleware/bodyParser/getCharset.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/getCharset.ts#L11">home/runner/work/opine/opine/src/middleware/bodyParser/getCharset.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_json_.html
+++ b/docs/modules/_middleware_bodyparser_json_.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">FIRST_<wbr>CHAR_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /^[\x20\x09\x0a\x0d]*(.)/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/json.ts#L51">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/json.ts#L51">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:51</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/json.ts#L158">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/json.ts#L158">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -153,7 +153,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/json.ts#L180">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:180</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/json.ts#L180">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/json.ts#L60">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/json.ts#L60">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/json.ts#L191">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/json.ts#L191">home/runner/work/opine/opine/src/middleware/bodyParser/json.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_raw_.html
+++ b/docs/modules/_middleware_bodyparser_raw_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/raw.ts#L44">home/runner/work/opine/opine/src/middleware/bodyParser/raw.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/raw.ts#L44">home/runner/work/opine/opine/src/middleware/bodyParser/raw.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_read_.html
+++ b/docs/modules/_middleware_bodyparser_read_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/read.ts#L111">home/runner/work/opine/opine/src/middleware/bodyParser/read.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/read.ts#L111">home/runner/work/opine/opine/src/middleware/bodyParser/read.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/read.ts#L50">home/runner/work/opine/opine/src/middleware/bodyParser/read.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/read.ts#L50">home/runner/work/opine/opine/src/middleware/bodyParser/read.ts:50</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_text_.html
+++ b/docs/modules/_middleware_bodyparser_text_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/text.ts#L45">home/runner/work/opine/opine/src/middleware/bodyParser/text.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/text.ts#L45">home/runner/work/opine/opine/src/middleware/bodyParser/text.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_typechecker_.html
+++ b/docs/modules/_middleware_bodyparser_typechecker_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/typeChecker.ts#L41">home/runner/work/opine/opine/src/middleware/bodyParser/typeChecker.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/typeChecker.ts#L41">home/runner/work/opine/opine/src/middleware/bodyParser/typeChecker.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_bodyparser_urlencoded_.html
+++ b/docs/modules/_middleware_bodyparser_urlencoded_.html
@@ -93,7 +93,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/urlencoded.ts#L224">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/urlencoded.ts#L224">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:224</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/urlencoded.ts#L160">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:160</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/urlencoded.ts#L160">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:160</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/urlencoded.ts#L201">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:201</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/urlencoded.ts#L201">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:201</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/urlencoded.ts#L124">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:124</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/urlencoded.ts#L124">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:124</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/bodyParser/urlencoded.ts#L46">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/bodyParser/urlencoded.ts#L46">home/runner/work/opine/opine/src/middleware/bodyParser/urlencoded.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_init_.html
+++ b/docs/modules/_middleware_init_.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">create<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">create</span><span class="tsd-signature-symbol"> = Object.create</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/init.ts#L8">home/runner/work/opine/opine/src/middleware/init.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/init.ts#L8">home/runner/work/opine/opine/src/middleware/init.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>Prototype<wbr>Of<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = Object.setPrototypeOf</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/init.ts#L9">home/runner/work/opine/opine/src/middleware/init.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/init.ts#L9">home/runner/work/opine/opine/src/middleware/init.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/init.ts#L21">home/runner/work/opine/opine/src/middleware/init.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/init.ts#L21">home/runner/work/opine/opine/src/middleware/init.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_query_.html
+++ b/docs/modules/_middleware_query_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/query.ts#L13">home/runner/work/opine/opine/src/middleware/query.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/query.ts#L13">home/runner/work/opine/opine/src/middleware/query.ts:13</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_middleware_servestatic_.html
+++ b/docs/modules/_middleware_servestatic_.html
@@ -93,7 +93,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/serveStatic.ts#L122">home/runner/work/opine/opine/src/middleware/serveStatic.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/serveStatic.ts#L122">home/runner/work/opine/opine/src/middleware/serveStatic.ts:122</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/serveStatic.ts#L140">home/runner/work/opine/opine/src/middleware/serveStatic.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/serveStatic.ts#L140">home/runner/work/opine/opine/src/middleware/serveStatic.ts:140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/serveStatic.ts#L157">home/runner/work/opine/opine/src/middleware/serveStatic.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/serveStatic.ts#L157">home/runner/work/opine/opine/src/middleware/serveStatic.ts:157</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/serveStatic.ts#L171">home/runner/work/opine/opine/src/middleware/serveStatic.ts:171</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/serveStatic.ts#L171">home/runner/work/opine/opine/src/middleware/serveStatic.ts:171</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -220,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/middleware/serveStatic.ts#L55">home/runner/work/opine/opine/src/middleware/serveStatic.ts:55</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/middleware/serveStatic.ts#L55">home/runner/work/opine/opine/src/middleware/serveStatic.ts:55</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_opine_.html
+++ b/docs/modules/_opine_.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">request<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.opinerequest.html" class="tsd-signature-type">OpineRequest</a><span class="tsd-signature-symbol"> = Object.create(WrappedRequest.prototype)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/opine.ts#L19">home/runner/work/opine/opine/src/opine.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/opine.ts#L19">home/runner/work/opine/opine/src/opine.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">response<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.opineresponse.html" class="tsd-signature-type">OpineResponse</a><span class="tsd-signature-symbol"> = Object.create(ServerResponse.prototype)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/opine.ts#L18">home/runner/work/opine/opine/src/opine.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/opine.ts#L18">home/runner/work/opine/opine/src/opine.ts:18</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -124,7 +124,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/opine.ts#L27">home/runner/work/opine/opine/src/opine.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/opine.ts#L27">home/runner/work/opine/opine/src/opine.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_request_.html
+++ b/docs/modules/_request_.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L25">home/runner/work/opine/opine/src/request.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L25">home/runner/work/opine/opine/src/request.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Deno.Reader</span></h4>
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/request.ts#L33">home/runner/work/opine/opine/src/request.ts:33</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/request.ts#L33">home/runner/work/opine/opine/src/request.ts:33</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_router_index_.html
+++ b/docs/modules/_router_index_.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">Router<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.routerconstructor.html" class="tsd-signature-type">RouterConstructor</a><span class="tsd-signature-symbol"> = function (options: any &#x3D; {}): any {function router(req: OpineRequest,res: OpineResponse,next: NextFunction,): void {(router as any).handle(req, res, next);}setPrototypeOf(router, Router);router.params &#x3D; {};router._params &#x3D; [] as any[];router.caseSensitive &#x3D; options.caseSensitive;router.mergeParams &#x3D; options.mergeParams;router.strict &#x3D; options.strict;router.stack &#x3D; [] as any[];return router as IRouter;} as any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L25">home/runner/work/opine/opine/src/router/index.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L25">home/runner/work/opine/opine/src/router/index.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">object<wbr>Reg<wbr>Exp<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /^\[object (\S+)\]$/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L15">home/runner/work/opine/opine/src/router/index.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L15">home/runner/work/opine/opine/src/router/index.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>Prototype<wbr>Of<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = Object.setPrototypeOf</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L16">home/runner/work/opine/opine/src/router/index.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L16">home/runner/work/opine/opine/src/router/index.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L514">home/runner/work/opine/opine/src/router/index.ts:514</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L514">home/runner/work/opine/opine/src/router/index.ts:514</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -175,7 +175,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L524">home/runner/work/opine/opine/src/router/index.ts:524</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L524">home/runner/work/opine/opine/src/router/index.ts:524</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -198,7 +198,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L539">home/runner/work/opine/opine/src/router/index.ts:539</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L539">home/runner/work/opine/opine/src/router/index.ts:539</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -221,7 +221,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L558">home/runner/work/opine/opine/src/router/index.ts:558</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L558">home/runner/work/opine/opine/src/router/index.ts:558</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -252,7 +252,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L567">home/runner/work/opine/opine/src/router/index.ts:567</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L567">home/runner/work/opine/opine/src/router/index.ts:567</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -278,7 +278,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L606">home/runner/work/opine/opine/src/router/index.ts:606</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L606">home/runner/work/opine/opine/src/router/index.ts:606</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L626">home/runner/work/opine/opine/src/router/index.ts:626</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L626">home/runner/work/opine/opine/src/router/index.ts:626</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -333,7 +333,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/index.ts#L641">home/runner/work/opine/opine/src/router/index.ts:641</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/index.ts#L641">home/runner/work/opine/opine/src/router/index.ts:641</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_router_layer_.html
+++ b/docs/modules/_router_layer_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/layer.ts#L4">home/runner/work/opine/opine/src/router/layer.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/layer.ts#L4">home/runner/work/opine/opine/src/router/layer.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/layer.ts#L148">home/runner/work/opine/opine/src/router/layer.ts:148</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/layer.ts#L148">home/runner/work/opine/opine/src/router/layer.ts:148</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_router_route_.html
+++ b/docs/modules/_router_route_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/router/route.ts#L11">home/runner/work/opine/opine/src/router/route.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/router/route.ts#L11">home/runner/work/opine/opine/src/router/route.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_types_.html
+++ b/docs/modules/_types_.html
@@ -137,7 +137,7 @@
 					<div class="tsd-signature tsd-kind-icon">Application<wbr>Request<wbr>Handler&lt;T&gt;<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.irouterhandler.html" class="tsd-signature-type">IRouterHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><a href="../interfaces/_types_.iroutermatcher.html" class="tsd-signature-type">IRouterMatcher</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>handlers<span class="tsd-signature-symbol">: </span><a href="_types_.html#requesthandlerparams" class="tsd-signature-type">RequestHandlerParams</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1040">home/runner/work/opine/opine/src/types.ts:1040</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1043">home/runner/work/opine/opine/src/types.ts:1043</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -153,7 +153,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cookie<wbr>Options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_types_.cookie.html" class="tsd-signature-type">Cookie</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"name"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"value"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L91">home/runner/work/opine/opine/src/types.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L94">home/runner/work/opine/opine/src/types.ts:94</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">Cookie<wbr>With<wbr>Optional<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_types_.cookie.html" class="tsd-signature-type">Cookie</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"value"</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>value<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Cookie</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">"value"</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L87">home/runner/work/opine/opine/src/types.ts:87</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L90">home/runner/work/opine/opine/src/types.ts:90</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">Deno<wbr>Response<wbr>Body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Uint8Array</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Deno.Reader</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L24">home/runner/work/opine/opine/src/types.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L27">home/runner/work/opine/opine/src/types.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">Errback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>err<span class="tsd-signature-symbol">: </span><a href="../classes/_utils_createerror_.httperror.html#error" class="tsd-signature-type">Error</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L256">home/runner/work/opine/opine/src/types.ts:256</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L259">home/runner/work/opine/opine/src/types.ts:259</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -214,7 +214,7 @@
 					<div class="tsd-signature tsd-kind-icon">Error<wbr>Request<wbr>Handler&lt;P, ResBody, ReqQuery&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>err<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, req<span class="tsd-signature-symbol">: </span><a href="../interfaces/_types_.opinerequest.html" class="tsd-signature-type">OpineRequest</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ReqQuery</span><span class="tsd-signature-symbol">&gt;</span>, res<span class="tsd-signature-symbol">: </span><a href="../interfaces/_types_.opineresponse.html" class="tsd-signature-type">OpineResponse</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">&gt;</span>, next<span class="tsd-signature-symbol">: </span><a href="../interfaces/_types_.nextfunction.html" class="tsd-signature-type">NextFunction</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L65">home/runner/work/opine/opine/src/types.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L68">home/runner/work/opine/opine/src/types.ts:68</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -266,17 +266,17 @@
 					<div class="tsd-signature tsd-kind-icon">HTTPOptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Deno.ListenOptions</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"transport"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L21">home/runner/work/opine/opine/src/types.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L21">home/runner/work/opine/opine/src/types.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-type-alias tsd-parent-kind-module">
 					<a name="httpsoptions" class="tsd-anchor"></a>
 					<h3>HTTPSOptions</h3>
-					<div class="tsd-signature tsd-kind-icon">HTTPSOptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Deno.ListenTlsOptions</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"transport"</span><span class="tsd-signature-symbol">&gt;</span></div>
+					<div class="tsd-signature tsd-kind-icon">HTTPSOptions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Deno.ListenTlsOptions</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>certFile<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>keyFile<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"transport"</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L22">home/runner/work/opine/opine/src/types.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L22">home/runner/work/opine/opine/src/types.ts:22</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -286,7 +286,7 @@
 					<div class="tsd-signature tsd-kind-icon">Params<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.paramsdictionary.html" class="tsd-signature-type">ParamsDictionary</a><span class="tsd-signature-symbol"> | </span><a href="_types_.html#paramsarray" class="tsd-signature-type">ParamsArray</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L51">home/runner/work/opine/opine/src/types.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L54">home/runner/work/opine/opine/src/types.ts:54</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -296,7 +296,7 @@
 					<div class="tsd-signature tsd-kind-icon">Params<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L50">home/runner/work/opine/opine/src/types.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L53">home/runner/work/opine/opine/src/types.ts:53</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -306,7 +306,7 @@
 					<div class="tsd-signature tsd-kind-icon">ParsedURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">URL</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span>_raw<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">; </span>path<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol">; </span>query<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L258">home/runner/work/opine/opine/src/types.ts:258</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L261">home/runner/work/opine/opine/src/types.ts:261</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -316,7 +316,7 @@
 					<div class="tsd-signature tsd-kind-icon">Path<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_types_.rangeparserranges.html#array" class="tsd-signature-type">Array</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L76">home/runner/work/opine/opine/src/types.ts:76</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L79">home/runner/work/opine/opine/src/types.ts:79</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -326,7 +326,7 @@
 					<div class="tsd-signature tsd-kind-icon">Range<wbr>Parser<wbr>Result<span class="tsd-signature-symbol">:</span> <a href="_types_.html#rangeparserresultunsatisfiable" class="tsd-signature-type">RangeParserResultUnsatisfiable</a><span class="tsd-signature-symbol"> | </span><a href="_types_.html#rangeparserresultinvalid" class="tsd-signature-type">RangeParserResultInvalid</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L283">home/runner/work/opine/opine/src/types.ts:283</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L286">home/runner/work/opine/opine/src/types.ts:286</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -336,7 +336,7 @@
 					<div class="tsd-signature tsd-kind-icon">Range<wbr>Parser<wbr>Result<wbr>Invalid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">-2</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L282">home/runner/work/opine/opine/src/types.ts:282</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L285">home/runner/work/opine/opine/src/types.ts:285</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -346,7 +346,7 @@
 					<div class="tsd-signature tsd-kind-icon">Range<wbr>Parser<wbr>Result<wbr>Unsatisfiable<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">-1</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L281">home/runner/work/opine/opine/src/types.ts:281</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L284">home/runner/work/opine/opine/src/types.ts:284</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -356,7 +356,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request<wbr>Handler<wbr>Params&lt;P, ResBody, ReqQuery&gt;<span class="tsd-signature-symbol">:</span> <a href="../interfaces/_types_.requesthandler.html" class="tsd-signature-type">RequestHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ReqQuery</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="_types_.html#errorrequesthandler" class="tsd-signature-type">ErrorRequestHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ReqQuery</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_types_.rangeparserranges.html#array" class="tsd-signature-type">Array</a><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/_types_.requesthandler.html" class="tsd-signature-type">RequestHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="_types_.html#errorrequesthandler" class="tsd-signature-type">ErrorRequestHandler</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L78">home/runner/work/opine/opine/src/types.ts:78</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L81">home/runner/work/opine/opine/src/types.ts:81</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -378,7 +378,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request<wbr>Param<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><a href="../interfaces/_types_.opinerequest.html" class="tsd-signature-type">OpineRequest</a>, res<span class="tsd-signature-symbol">: </span><a href="../interfaces/_types_.opineresponse.html" class="tsd-signature-type">OpineResponse</a>, next<span class="tsd-signature-symbol">: </span><a href="../interfaces/_types_.nextfunction.html" class="tsd-signature-type">NextFunction</a>, value<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, name<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L1032">home/runner/work/opine/opine/src/types.ts:1032</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L1035">home/runner/work/opine/opine/src/types.ts:1035</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -421,7 +421,7 @@
 					<div class="tsd-signature tsd-kind-icon">Response<wbr>Body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="_types_.html#denoresponsebody" class="tsd-signature-type">DenoResponseBody</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L25">home/runner/work/opine/opine/src/types.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L28">home/runner/work/opine/opine/src/types.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -431,7 +431,7 @@
 					<div class="tsd-signature tsd-kind-icon">Send&lt;ResBody, T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>body<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ResBody</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/types.ts#L630">home/runner/work/opine/opine/src/types.ts:630</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/types.ts#L633">home/runner/work/opine/opine/src/types.ts:633</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/modules/_utils_compileetag_.html
+++ b/docs/modules/_utils_compileetag_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">etag<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol"> = createETagGenerator({ weak: false })</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileETag.ts#L25">home/runner/work/opine/opine/src/utils/compileETag.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileETag.ts#L25">home/runner/work/opine/opine/src/utils/compileETag.ts:25</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">wetag<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol"> = createETagGenerator({ weak: true })</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileETag.ts#L35">home/runner/work/opine/opine/src/utils/compileETag.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileETag.ts#L35">home/runner/work/opine/opine/src/utils/compileETag.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -146,7 +146,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileETag.ts#L44">home/runner/work/opine/opine/src/utils/compileETag.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileETag.ts#L44">home/runner/work/opine/opine/src/utils/compileETag.ts:44</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileETag.ts#L11">home/runner/work/opine/opine/src/utils/compileETag.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileETag.ts#L11">home/runner/work/opine/opine/src/utils/compileETag.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_compilequeryparser_.html
+++ b/docs/modules/_utils_compilequeryparser_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">Query<wbr>Parser<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"extended"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"simple"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileQueryParser.ts#L25">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileQueryParser.ts#L25">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileQueryParser.ts#L34">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileQueryParser.ts#L34">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:34</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileQueryParser.ts#L9">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileQueryParser.ts#L9">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileQueryParser.ts#L19">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileQueryParser.ts#L19">home/runner/work/opine/opine/src/utils/compileQueryParser.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_compiletrust_.html
+++ b/docs/modules/_utils_compiletrust_.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">Trust<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Function</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileTrust.ts#L3">home/runner/work/opine/opine/src/utils/compileTrust.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileTrust.ts#L3">home/runner/work/opine/opine/src/utils/compileTrust.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/compileTrust.ts#L12">home/runner/work/opine/opine/src/utils/compileTrust.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/compileTrust.ts#L12">home/runner/work/opine/opine/src/utils/compileTrust.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_contentdisposition_.html
+++ b/docs/modules/_utils_contentdisposition_.html
@@ -102,7 +102,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENCODE_<wbr>URL_<wbr>ATTR_<wbr>CHAR_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /[\x00-\x20&quot;&#x27;()*,/:;&lt;&#x3D;&gt;?@[\\\]{}\x7f]/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L38">home/runner/work/opine/opine/src/utils/contentDisposition.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L38">home/runner/work/opine/opine/src/utils/contentDisposition.ts:38</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -117,7 +117,7 @@
 					<div class="tsd-signature tsd-kind-icon">HEX_<wbr>ESCAPE_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /%[0-9A-Fa-f]{2}/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L44">home/runner/work/opine/opine/src/utils/contentDisposition.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L44">home/runner/work/opine/opine/src/utils/contentDisposition.ts:44</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">NON_<wbr>LATIN1_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /[^\x20-\x7e\xa0-\xff]/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L50">home/runner/work/opine/opine/src/utils/contentDisposition.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L50">home/runner/work/opine/opine/src/utils/contentDisposition.ts:50</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">QUOTE_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /([\\&quot;])/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L56">home/runner/work/opine/opine/src/utils/contentDisposition.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L56">home/runner/work/opine/opine/src/utils/contentDisposition.ts:56</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">TEXT_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /^[\x20-\x7e\x80-\xff]+$/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L82">home/runner/work/opine/opine/src/utils/contentDisposition.ts:82</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L82">home/runner/work/opine/opine/src/utils/contentDisposition.ts:82</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">TOKEN_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /^[!#$%&amp;&#x27;*+.0-9A-Z^_&#x60;a-z|~-]+$/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L83">home/runner/work/opine/opine/src/utils/contentDisposition.ts:83</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L83">home/runner/work/opine/opine/src/utils/contentDisposition.ts:83</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L227">home/runner/work/opine/opine/src/utils/contentDisposition.ts:227</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L227">home/runner/work/opine/opine/src/utils/contentDisposition.ts:227</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L104">home/runner/work/opine/opine/src/utils/contentDisposition.ts:104</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L104">home/runner/work/opine/opine/src/utils/contentDisposition.ts:104</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L191">home/runner/work/opine/opine/src/utils/contentDisposition.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L191">home/runner/work/opine/opine/src/utils/contentDisposition.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -309,7 +309,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L92">home/runner/work/opine/opine/src/utils/contentDisposition.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L92">home/runner/work/opine/opine/src/utils/contentDisposition.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L158">home/runner/work/opine/opine/src/utils/contentDisposition.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L158">home/runner/work/opine/opine/src/utils/contentDisposition.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L145">home/runner/work/opine/opine/src/utils/contentDisposition.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L145">home/runner/work/opine/opine/src/utils/contentDisposition.ts:145</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -393,7 +393,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/contentDisposition.ts#L172">home/runner/work/opine/opine/src/utils/contentDisposition.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/contentDisposition.ts#L172">home/runner/work/opine/opine/src/utils/contentDisposition.ts:172</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_cookies_.html
+++ b/docs/modules/_utils_cookies_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/cookies.ts#L8">home/runner/work/opine/opine/src/utils/cookies.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/cookies.ts#L8">home/runner/work/opine/opine/src/utils/cookies.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -123,7 +123,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/cookies.ts#L19">home/runner/work/opine/opine/src/utils/cookies.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/cookies.ts#L19">home/runner/work/opine/opine/src/utils/cookies.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_createerror_.html
+++ b/docs/modules/_utils_createerror_.html
@@ -105,7 +105,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L85">home/runner/work/opine/opine/src/utils/createError.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L85">home/runner/work/opine/opine/src/utils/createError.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L90">home/runner/work/opine/opine/src/utils/createError.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L90">home/runner/work/opine/opine/src/utils/createError.ts:90</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -147,7 +147,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/createError.ts#L91">home/runner/work/opine/opine/src/utils/createError.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/createError.ts#L91">home/runner/work/opine/opine/src/utils/createError.ts:91</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_utils_definegetter_.html
+++ b/docs/modules/_utils_definegetter_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/defineGetter.ts#L9">home/runner/work/opine/opine/src/utils/defineGetter.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/defineGetter.ts#L9">home/runner/work/opine/opine/src/utils/defineGetter.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_etag_.html
+++ b/docs/modules/_utils_etag_.html
@@ -95,7 +95,7 @@
 					<div class="tsd-signature tsd-kind-icon">decoder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TextDecoder</span><span class="tsd-signature-symbol"> = new TextDecoder()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/etag.ts#L34">home/runner/work/opine/opine/src/utils/etag.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/etag.ts#L34">home/runner/work/opine/opine/src/utils/etag.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">encoder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TextEncoder</span><span class="tsd-signature-symbol"> = new TextEncoder()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/etag.ts#L33">home/runner/work/opine/opine/src/utils/etag.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/etag.ts#L33">home/runner/work/opine/opine/src/utils/etag.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/etag.ts#L43">home/runner/work/opine/opine/src/utils/etag.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/etag.ts#L43">home/runner/work/opine/opine/src/utils/etag.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -150,7 +150,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/etag.ts#L106">home/runner/work/opine/opine/src/utils/etag.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/etag.ts#L106">home/runner/work/opine/opine/src/utils/etag.ts:106</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/etag.ts#L74">home/runner/work/opine/opine/src/utils/etag.ts:74</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/etag.ts#L74">home/runner/work/opine/opine/src/utils/etag.ts:74</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/etag.ts#L90">home/runner/work/opine/opine/src/utils/etag.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/etag.ts#L90">home/runner/work/opine/opine/src/utils/etag.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_finalhandler_.html
+++ b/docs/modules/_utils_finalhandler_.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">DOUBLE_<wbr>SPACE_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /\x20{2}/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L40">home/runner/work/opine/opine/src/utils/finalHandler.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L40">home/runner/work/opine/opine/src/utils/finalHandler.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">NEWLINE_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /\n/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L41">home/runner/work/opine/opine/src/utils/finalHandler.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L41">home/runner/work/opine/opine/src/utils/finalHandler.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L49">home/runner/work/opine/opine/src/utils/finalHandler.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L49">home/runner/work/opine/opine/src/utils/finalHandler.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -155,7 +155,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L78">home/runner/work/opine/opine/src/utils/finalHandler.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L78">home/runner/work/opine/opine/src/utils/finalHandler.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L120">home/runner/work/opine/opine/src/utils/finalHandler.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L120">home/runner/work/opine/opine/src/utils/finalHandler.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L145">home/runner/work/opine/opine/src/utils/finalHandler.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L145">home/runner/work/opine/opine/src/utils/finalHandler.ts:145</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -245,7 +245,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L164">home/runner/work/opine/opine/src/utils/finalHandler.ts:164</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L164">home/runner/work/opine/opine/src/utils/finalHandler.ts:164</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -273,7 +273,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L183">home/runner/work/opine/opine/src/utils/finalHandler.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L183">home/runner/work/opine/opine/src/utils/finalHandler.ts:183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -303,7 +303,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L198">home/runner/work/opine/opine/src/utils/finalHandler.ts:198</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L198">home/runner/work/opine/opine/src/utils/finalHandler.ts:198</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -331,7 +331,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L219">home/runner/work/opine/opine/src/utils/finalHandler.ts:219</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L219">home/runner/work/opine/opine/src/utils/finalHandler.ts:219</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -371,7 +371,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/finalHandler.ts#L259">home/runner/work/opine/opine/src/utils/finalHandler.ts:259</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/finalHandler.ts#L259">home/runner/work/opine/opine/src/utils/finalHandler.ts:259</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_forwarded_.html
+++ b/docs/modules/_utils_forwarded_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/forwarded.ts#L39">home/runner/work/opine/opine/src/utils/forwarded.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/forwarded.ts#L39">home/runner/work/opine/opine/src/utils/forwarded.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -118,7 +118,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/forwarded.ts#L59">home/runner/work/opine/opine/src/utils/forwarded.ts:59</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/forwarded.ts#L59">home/runner/work/opine/opine/src/utils/forwarded.ts:59</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_fresh_.html
+++ b/docs/modules/_utils_fresh_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>CONTROL_<wbr>NO_<wbr>CACHE_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /(?:^|,)\s*?no-cache\s*?(?:,|$)/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/fresh.ts#L32">home/runner/work/opine/opine/src/utils/fresh.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/fresh.ts#L32">home/runner/work/opine/opine/src/utils/fresh.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/fresh.ts#L42">home/runner/work/opine/opine/src/utils/fresh.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/fresh.ts#L42">home/runner/work/opine/opine/src/utils/fresh.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/fresh.ts#L103">home/runner/work/opine/opine/src/utils/fresh.ts:103</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/fresh.ts#L103">home/runner/work/opine/opine/src/utils/fresh.ts:103</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/fresh.ts#L115">home/runner/work/opine/opine/src/utils/fresh.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/fresh.ts#L115">home/runner/work/opine/opine/src/utils/fresh.ts:115</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_merge_.html
+++ b/docs/modules/_utils_merge_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/merge.ts#L9">home/runner/work/opine/opine/src/utils/merge.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/merge.ts#L9">home/runner/work/opine/opine/src/utils/merge.ts:9</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_mergedescriptors_.html
+++ b/docs/modules/_utils_mergedescriptors_.html
@@ -91,7 +91,7 @@
 					<div class="tsd-signature tsd-kind-icon">has<wbr>Own<wbr>Property<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">hasOwnProperty</span><span class="tsd-signature-symbol"> = Object.prototype.hasOwnProperty</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/mergeDescriptors.ts#L32">home/runner/work/opine/opine/src/utils/mergeDescriptors.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/mergeDescriptors.ts#L32">home/runner/work/opine/opine/src/utils/mergeDescriptors.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/mergeDescriptors.ts#L43">home/runner/work/opine/opine/src/utils/mergeDescriptors.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/mergeDescriptors.ts#L43">home/runner/work/opine/opine/src/utils/mergeDescriptors.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_normalizetype_.html
+++ b/docs/modules/_utils_normalizetype_.html
@@ -91,7 +91,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/normalizeType.ts#L11">home/runner/work/opine/opine/src/utils/normalizeType.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/normalizeType.ts#L11">home/runner/work/opine/opine/src/utils/normalizeType.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/normalizeType.ts#L35">home/runner/work/opine/opine/src/utils/normalizeType.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/normalizeType.ts#L35">home/runner/work/opine/opine/src/utils/normalizeType.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/normalizeType.ts#L48">home/runner/work/opine/opine/src/utils/normalizeType.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/normalizeType.ts#L48">home/runner/work/opine/opine/src/utils/normalizeType.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_parseurl_.html
+++ b/docs/modules/_utils_parseurl_.html
@@ -92,7 +92,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/parseUrl.ts#L99">home/runner/work/opine/opine/src/utils/parseUrl.ts:99</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/parseUrl.ts#L99">home/runner/work/opine/opine/src/utils/parseUrl.ts:99</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -120,7 +120,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/parseUrl.ts#L156">home/runner/work/opine/opine/src/utils/parseUrl.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/parseUrl.ts#L156">home/runner/work/opine/opine/src/utils/parseUrl.ts:156</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -151,7 +151,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/parseUrl.ts#L70">home/runner/work/opine/opine/src/utils/parseUrl.ts:70</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/parseUrl.ts#L70">home/runner/work/opine/opine/src/utils/parseUrl.ts:70</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/parseUrl.ts#L41">home/runner/work/opine/opine/src/utils/parseUrl.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/parseUrl.ts#L41">home/runner/work/opine/opine/src/utils/parseUrl.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_pathtoregex_.html
+++ b/docs/modules/_utils_pathtoregex_.html
@@ -71,7 +71,7 @@
 					</div>
 					<p>Licensed as follows:</p>
 					<p>The MIT License (MIT)</p>
-					<p>Copyright (c) 2014 Blake Embrey (<a href="mailto:&#x68;&#x65;&#108;&#x6c;&#111;&#64;&#x62;&#x6c;&#97;&#107;&#101;&#101;&#x6d;&#x62;&#114;&#101;&#121;&#x2e;&#x63;&#x6f;&#109;">&#x68;&#x65;&#108;&#x6c;&#111;&#64;&#x62;&#x6c;&#97;&#107;&#101;&#101;&#x6d;&#x62;&#114;&#101;&#121;&#x2e;&#x63;&#x6f;&#109;</a>)</p>
+					<p>Copyright (c) 2014 Blake Embrey (<a href="mailto:&#x68;&#101;&#108;&#x6c;&#x6f;&#x40;&#x62;&#108;&#97;&#107;&#x65;&#101;&#x6d;&#x62;&#x72;&#101;&#x79;&#x2e;&#x63;&#111;&#109;">&#x68;&#101;&#108;&#x6c;&#x6f;&#x40;&#x62;&#108;&#97;&#107;&#x65;&#101;&#x6d;&#x62;&#x72;&#101;&#x79;&#x2e;&#x63;&#111;&#109;</a>)</p>
 					<p>Permission is hereby granted, free of charge, to any person obtaining a copy
 						of this software and associated documentation files (the &quot;Software&quot;), to deal
 						in the Software without restriction, including without limitation the rights
@@ -123,7 +123,7 @@
 					<div class="tsd-signature tsd-kind-icon">Path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> | </span><a href="_utils_pathtoregex_.html#patharray" class="tsd-signature-type">PathArray</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/pathToRegex.ts#L35">home/runner/work/opine/opine/src/utils/pathToRegex.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/pathToRegex.ts#L35">home/runner/work/opine/opine/src/utils/pathToRegex.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -133,7 +133,7 @@
 					<div class="tsd-signature tsd-kind-icon">Path<wbr>Array<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/pathToRegex.ts#L34">home/runner/work/opine/opine/src/utils/pathToRegex.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/pathToRegex.ts#L34">home/runner/work/opine/opine/src/utils/pathToRegex.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -146,7 +146,7 @@
 					<div class="tsd-signature tsd-kind-icon">MATCHING_<wbr>GROUP_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /\((?!\?)/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/pathToRegex.ts#L32">home/runner/work/opine/opine/src/utils/pathToRegex.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/pathToRegex.ts#L32">home/runner/work/opine/opine/src/utils/pathToRegex.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/pathToRegex.ts#L52">home/runner/work/opine/opine/src/utils/pathToRegex.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/pathToRegex.ts#L52">home/runner/work/opine/opine/src/utils/pathToRegex.ts:52</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_utils_proxyaddr_.html
+++ b/docs/modules/_utils_proxyaddr_.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">DIGIT_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /^[0-9]+$/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L34">home/runner/work/opine/opine/src/utils/proxyAddr.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L34">home/runner/work/opine/opine/src/utils/proxyAddr.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -118,7 +118,7 @@
 					<div class="tsd-signature tsd-kind-icon">isip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = ipaddr.isValid</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L35">home/runner/work/opine/opine/src/utils/proxyAddr.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L35">home/runner/work/opine/opine/src/utils/proxyAddr.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">parseip<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = ipaddr.parse</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L36">home/runner/work/opine/opine/src/utils/proxyAddr.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L36">home/runner/work/opine/opine/src/utils/proxyAddr.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -145,7 +145,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L57">home/runner/work/opine/opine/src/utils/proxyAddr.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L57">home/runner/work/opine/opine/src/utils/proxyAddr.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -177,7 +177,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L85">home/runner/work/opine/opine/src/utils/proxyAddr.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L85">home/runner/work/opine/opine/src/utils/proxyAddr.ts:85</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -205,7 +205,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L122">home/runner/work/opine/opine/src/utils/proxyAddr.ts:122</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L122">home/runner/work/opine/opine/src/utils/proxyAddr.ts:122</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -233,7 +233,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L138">home/runner/work/opine/opine/src/utils/proxyAddr.ts:138</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L138">home/runner/work/opine/opine/src/utils/proxyAddr.ts:138</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -261,7 +261,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L199">home/runner/work/opine/opine/src/utils/proxyAddr.ts:199</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L199">home/runner/work/opine/opine/src/utils/proxyAddr.ts:199</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -289,7 +289,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L155">home/runner/work/opine/opine/src/utils/proxyAddr.ts:155</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L155">home/runner/work/opine/opine/src/utils/proxyAddr.ts:155</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -317,7 +317,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L213">home/runner/work/opine/opine/src/utils/proxyAddr.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L213">home/runner/work/opine/opine/src/utils/proxyAddr.ts:213</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -348,7 +348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L246">home/runner/work/opine/opine/src/utils/proxyAddr.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L246">home/runner/work/opine/opine/src/utils/proxyAddr.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L236">home/runner/work/opine/opine/src/utils/proxyAddr.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L236">home/runner/work/opine/opine/src/utils/proxyAddr.ts:236</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -398,7 +398,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L292">home/runner/work/opine/opine/src/utils/proxyAddr.ts:292</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L292">home/runner/work/opine/opine/src/utils/proxyAddr.ts:292</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -425,7 +425,7 @@
 					<div class="tsd-signature tsd-kind-icon">IP_<wbr>RANGES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L43">home/runner/work/opine/opine/src/utils/proxyAddr.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L43">home/runner/work/opine/opine/src/utils/proxyAddr.ts:43</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -439,7 +439,7 @@
 						<div class="tsd-signature tsd-kind-icon">linklocal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&quot;169.254.0.0/16&quot;, &quot;fe80::/10&quot;]</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L44">home/runner/work/opine/opine/src/utils/proxyAddr.ts:44</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L44">home/runner/work/opine/opine/src/utils/proxyAddr.ts:44</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -449,7 +449,7 @@
 						<div class="tsd-signature tsd-kind-icon">loopback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&quot;127.0.0.1/8&quot;, &quot;::1/128&quot;]</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L45">home/runner/work/opine/opine/src/utils/proxyAddr.ts:45</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L45">home/runner/work/opine/opine/src/utils/proxyAddr.ts:45</a></li>
 							</ul>
 						</aside>
 					</section>
@@ -459,7 +459,7 @@
 						<div class="tsd-signature tsd-kind-icon">uniquelocal<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [&quot;10.0.0.0/8&quot;, &quot;172.16.0.0/12&quot;, &quot;192.168.0.0/16&quot;, &quot;fc00::/7&quot;]</span></div>
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/proxyAddr.ts#L46">home/runner/work/opine/opine/src/utils/proxyAddr.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/proxyAddr.ts#L46">home/runner/work/opine/opine/src/utils/proxyAddr.ts:46</a></li>
 							</ul>
 						</aside>
 					</section>

--- a/docs/modules/_utils_send_.html
+++ b/docs/modules/_utils_send_.html
@@ -145,7 +145,7 @@
 					<div class="tsd-signature tsd-kind-icon">BYTES_<wbr>RANGE_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /^ *bytes&#x3D;/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L47">home/runner/work/opine/opine/src/utils/send.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L47">home/runner/work/opine/opine/src/utils/send.ts:47</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENAMETOOLONG_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /\(os error 63\)|\(os error 36\)|\(os error 123\)/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L62">home/runner/work/opine/opine/src/utils/send.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L62">home/runner/work/opine/opine/src/utils/send.ts:62</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENCODE_<wbr>CHARS_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /(?:[^\x21\x25\x26-\x3B\x3D\x3F-\x5B\x5D\x5F\x61-\x7A\x7E]|%(?:[^0-9A-Fa-f]|[0-9A-Fa-f][^0-9A-Fa-f]|$))+/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L623">home/runner/work/opine/opine/src/utils/send.ts:623</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L623">home/runner/work/opine/opine/src/utils/send.ts:623</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">ENOENT_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /\(os error 2\)/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L61">home/runner/work/opine/opine/src/utils/send.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L61">home/runner/work/opine/opine/src/utils/send.ts:61</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">MAX_<wbr>MAXAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 60 * 60 * 24 * 365 * 1000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L53">home/runner/work/opine/opine/src/utils/send.ts:53</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L53">home/runner/work/opine/opine/src/utils/send.ts:53</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNMATCHED_<wbr>SURROGATE_<wbr>PAIR_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /(^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF]([^\uDC00-\uDFFF]|$)/g</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L630">home/runner/work/opine/opine/src/utils/send.ts:630</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L630">home/runner/work/opine/opine/src/utils/send.ts:630</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNMATCHED_<wbr>SURROGATE_<wbr>PAIR_<wbr>REPLACE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"$1�$2"</span><span class="tsd-signature-symbol"> = &quot;$1�$2&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L637">home/runner/work/opine/opine/src/utils/send.ts:637</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L637">home/runner/work/opine/opine/src/utils/send.ts:637</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">UP_<wbr>PATH_<wbr>REGEXP<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /(?:^|[\\/])\.\.(?:[\\/]|$)/</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L59">home/runner/work/opine/opine/src/utils/send.ts:59</a></li>
+							<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L59">home/runner/work/opine/opine/src/utils/send.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L367">home/runner/work/opine/opine/src/utils/send.ts:367</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L367">home/runner/work/opine/opine/src/utils/send.ts:367</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -305,7 +305,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L250">home/runner/work/opine/opine/src/utils/send.ts:250</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L250">home/runner/work/opine/opine/src/utils/send.ts:250</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -333,7 +333,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L232">home/runner/work/opine/opine/src/utils/send.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L232">home/runner/work/opine/opine/src/utils/send.ts:232</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -361,7 +361,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L91">home/runner/work/opine/opine/src/utils/send.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L91">home/runner/work/opine/opine/src/utils/send.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -389,7 +389,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L168">home/runner/work/opine/opine/src/utils/send.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L168">home/runner/work/opine/opine/src/utils/send.ts:168</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -423,7 +423,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L265">home/runner/work/opine/opine/src/utils/send.ts:265</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L265">home/runner/work/opine/opine/src/utils/send.ts:265</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -445,7 +445,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L610">home/runner/work/opine/opine/src/utils/send.ts:610</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L610">home/runner/work/opine/opine/src/utils/send.ts:610</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L656">home/runner/work/opine/opine/src/utils/send.ts:656</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L656">home/runner/work/opine/opine/src/utils/send.ts:656</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -511,7 +511,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L110">home/runner/work/opine/opine/src/utils/send.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L110">home/runner/work/opine/opine/src/utils/send.ts:110</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -539,7 +539,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L195">home/runner/work/opine/opine/src/utils/send.ts:195</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L195">home/runner/work/opine/opine/src/utils/send.ts:195</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -568,7 +568,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L120">home/runner/work/opine/opine/src/utils/send.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L120">home/runner/work/opine/opine/src/utils/send.ts:120</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -596,7 +596,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L135">home/runner/work/opine/opine/src/utils/send.ts:135</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L135">home/runner/work/opine/opine/src/utils/send.ts:135</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -627,7 +627,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L206">home/runner/work/opine/opine/src/utils/send.ts:206</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L206">home/runner/work/opine/opine/src/utils/send.ts:206</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -658,7 +658,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L71">home/runner/work/opine/opine/src/utils/send.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L71">home/runner/work/opine/opine/src/utils/send.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -689,7 +689,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L320">home/runner/work/opine/opine/src/utils/send.ts:320</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L320">home/runner/work/opine/opine/src/utils/send.ts:320</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -726,7 +726,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L178">home/runner/work/opine/opine/src/utils/send.ts:178</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L178">home/runner/work/opine/opine/src/utils/send.ts:178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -754,7 +754,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L662">home/runner/work/opine/opine/src/utils/send.ts:662</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L662">home/runner/work/opine/opine/src/utils/send.ts:662</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -792,7 +792,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L280">home/runner/work/opine/opine/src/utils/send.ts:280</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L280">home/runner/work/opine/opine/src/utils/send.ts:280</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -823,7 +823,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L530">home/runner/work/opine/opine/src/utils/send.ts:530</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L530">home/runner/work/opine/opine/src/utils/send.ts:530</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -855,7 +855,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L561">home/runner/work/opine/opine/src/utils/send.ts:561</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L561">home/runner/work/opine/opine/src/utils/send.ts:561</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -887,7 +887,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/send.ts#L502">home/runner/work/opine/opine/src/utils/send.ts:502</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/send.ts#L502">home/runner/work/opine/opine/src/utils/send.ts:502</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_utils_stringify_.html
+++ b/docs/modules/_utils_stringify_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/utils/stringify.ts#L12">home/runner/work/opine/opine/src/utils/stringify.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/utils/stringify.ts#L12">home/runner/work/opine/opine/src/utils/stringify.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_view_.html
+++ b/docs/modules/_view_.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L25">home/runner/work/opine/opine/src/view.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L25">home/runner/work/opine/opine/src/view.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/cmorten/opine/blob/a5072bf/src/view.ts#L17">home/runner/work/opine/opine/src/view.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/AEtheve/opine/blob/8bcf2d4/src/view.ts#L17">home/runner/work/opine/opine/src/view.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ declare global {
 }
 
 export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
-export type HTTPSOptions = Omit<Deno.ListenTlsOptions, "transport">;
+export type HTTPSOptions = Omit<Deno.ListenTlsOptions & {"certFile":string, "keyFile":string}, "transport">;
 
 export type DenoResponseBody = undefined | string | Uint8Array | Deno.Reader;
 export type ResponseBody =

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,10 @@ declare global {
 }
 
 export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
-export type HTTPSOptions = Omit<Deno.ListenTlsOptions & {"certFile":string; "keyFile":string}, "transport">;
+export type HTTPSOptions = Omit<
+  Deno.ListenTlsOptions & { "certFile": string; "keyFile": string },
+  "transport"
+>;
 
 export type DenoResponseBody = undefined | string | Uint8Array | Deno.Reader;
 export type ResponseBody =

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ declare global {
 }
 
 export type HTTPOptions = Omit<Deno.ListenOptions, "transport">;
-export type HTTPSOptions = Omit<Deno.ListenTlsOptions & {"certFile":string, "keyFile":string}, "transport">;
+export type HTTPSOptions = Omit<Deno.ListenTlsOptions & {"certFile":string; "keyFile":string}, "transport">;
 
 export type DenoResponseBody = undefined | string | Uint8Array | Deno.Reader;
 export type ResponseBody =


### PR DESCRIPTION
# Issue

Fixes #164.

## Details

I just adjusted the httpsOptions type of opine so that the key and cert keys are  non-optional.

## CheckList

- [X] PR starts with [#ISSUE_ID].
- [X] Has been tested (where required).
